### PR TITLE
configs: Update directory /goattack -> /go_attack

### DIFF
--- a/configs/katago/analysis_custom.cfg
+++ b/configs/katago/analysis_custom.cfg
@@ -6,7 +6,7 @@
 # Logs------------------------------------------------------------------------------------
 
 # Where to output log?
-# logDir = /goattack/analysis_logs  # Each run of KataGo will log to a separate file in this dir
+# logDir = /go_attack/analysis_logs  # Each run of KataGo will log to a separate file in this dir
 # logFile = analysis.log  # Use this instead of logDir to just specify a single file directly
 # logToStderr = true      # Echo everything output to log file to stderr as well
 logAllRequests = true  # Log all input lines received to the analysis engine.

--- a/configs/katago/gtp_black.cfg
+++ b/configs/katago/gtp_black.cfg
@@ -47,7 +47,7 @@ player = BLACK
 # Logs and files--------------------------------------------------------------------------
 
 # Where to output log?
-# logDir = /goattack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
+# logDir = /go_attack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
 # logFile = gtp.log  # Use this instead of logDir to just specify a single file directly
 
 # Logging options

--- a/configs/katago/gtp_custom.cfg
+++ b/configs/katago/gtp_custom.cfg
@@ -45,7 +45,7 @@
 # Logs and files--------------------------------------------------------------------------
 
 # Where to output log?
-logDir = /goattack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
+logDir = /go_attack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
 # logFile = gtp.log  # Use this instead of logDir to just specify a single file directly
 
 # Logging options

--- a/configs/katago/gtp_develop.cfg
+++ b/configs/katago/gtp_develop.cfg
@@ -47,7 +47,7 @@
 # Logs and files--------------------------------------------------------------------------
 
 # Where to output log?
-# logDir = /goattack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
+# logDir = /go_attack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
 # logFile = gtp.log  # Use this instead of logDir to just specify a single file directly
 
 # Logging options

--- a/configs/katago/gtp_example.cfg
+++ b/configs/katago/gtp_example.cfg
@@ -45,7 +45,7 @@
 # Logs and files--------------------------------------------------------------------------
 
 # Where to output log?
-logDir = /goattack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
+logDir = /go_attack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
 # logFile = gtp.log  # Use this instead of logDir to just specify a single file directly
 
 # Logging options

--- a/configs/katago/gtp_white.cfg
+++ b/configs/katago/gtp_white.cfg
@@ -47,7 +47,7 @@ player = WHITE
 # Logs and files--------------------------------------------------------------------------
 
 # Where to output log?
-# logDir = /goattack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
+# logDir = /go_attack/gtp_logs    # Each run of KataGo will log to a separate file in this dir
 # logFile = gtp.log  # Use this instead of logDir to just specify a single file directly
 
 # Logging options


### PR DESCRIPTION
### Context

The following line in the README fails:

> - Test if the installation is successful
>   - `cd /engines/KataGo-custom/cpp/ && CUDA_VISIBLE_DEVICES=2 ./katago benchmark -model /go_attack/models/g170-b40c256x2-s5095420928-d1229425124.bin.gz -config /go_attack/configs/katago/gtp_custom.cfg`

with the error
```
terminate called after throwing an instance of 'StringError'
  what():  Error creating directory: /goattack/gtp_logs
Aborted (core dumped)
```
because we mount the repo at `/go_attack`, not `/goattack` in the following command from the README:

> - `docker run --gpus all -v ~/go_attack:/go_attack -it humancompatibleai/goattack:cpp`

We changed `/goattack` to `/go_attack` in the above `docker run` command in PR #9, but a corresponding path in `configs/katago/gtp_custom.cfg` was not updated.

### Changes

Change `/goattack` to `/go_attack` everywhere in `configs/` to fix the error.