### PR TITLE
Unset BASH_ENV in Dockerfile

### DIFF
--- a/compose/python/Dockerfile
+++ b/compose/python/Dockerfile
@@ -30,6 +30,9 @@ RUN apt-get update -q \
 ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV --system-site-packages
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+# NVidia Dockerfile sets BASH_ENV to source bashrc always which causes some
+# KataGo scripts to complain about unset PS1 -- unset this in the entrypoint.
+RUN echo "unset BASH_ENV" > /opt/nvidia/entrypoint.d/01-unset_bash_env.sh
 
 FROM build-deps as python-deps
 # Install python requirements within virtualenv


### PR DESCRIPTION
For some unknown reason NVidia's TensorFlow container sets BASH_ENV to always source /etc/bash.bashrc. This causes the shuffle script to complain vociferously about `unset PS1` (since bashrc tries to test it, and it's not present in the script). 

I can't see a good reason for this to be present in the first place 
 -- I assume it was useful for their build, but isn't actually needed to run things. Unfortunately Dockerfile's do not support unsetting environment variables directly (the most you can do is set it to an empty value). So, I add a script to the entrypoint to unset `BASH_ENV`.

Hacky, but seems to work OK.