### PR TITLE
Use same devices for both models when running `match`

### DIFF
--- a/configs/compute/1gpu.cfg
+++ b/configs/compute/1gpu.cfg
@@ -18,10 +18,10 @@ nnRandomize = true
 # cudaDeviceToUseModel0Thread0 = 3 #use device 3 for model 0, server thread 0
 # cudaDeviceToUseModel0Thread1 = 2 #use device 2 for model 0, server thread 1
 
-cudaDeviceToUseThread0 = 0
-cudaDeviceToUseThread1 = 0
-cudaDeviceToUseThread2 = 0
-cudaDeviceToUseThread3 = 0
+deviceToUseThread0 = 0
+deviceToUseThread1 = 0
+deviceToUseThread2 = 0
+deviceToUseThread3 = 0
 
-cudaUseFP16 = true
-cudaUseNHWC = true
+useFP16 = true
+useNHWC = true

--- a/configs/compute/2gpu.cfg
+++ b/configs/compute/2gpu.cfg
@@ -2,7 +2,7 @@
 
 numGameThreads = 400
 numNNServerThreadsPerModel = 8
-cudaDeviceToUseThread4 = 1
-cudaDeviceToUseThread5 = 1
-cudaDeviceToUseThread6 = 1
-cudaDeviceToUseThread7 = 1
+deviceToUseThread4 = 1
+deviceToUseThread5 = 1
+deviceToUseThread6 = 1
+deviceToUseThread7 = 1

--- a/configs/compute/3gpu.cfg
+++ b/configs/compute/3gpu.cfg
@@ -2,7 +2,7 @@
 
 numGameThreads = 600
 numNNServerThreadsPerModel = 12
-cudaDeviceToUseThread8 = 2
-cudaDeviceToUseThread9 = 2
-cudaDeviceToUseThread10 = 2
-cudaDeviceToUseThread11 = 2
+deviceToUseThread8 = 2
+deviceToUseThread9 = 2
+deviceToUseThread10 = 2
+deviceToUseThread11 = 2

--- a/configs/compute/4gpu.cfg
+++ b/configs/compute/4gpu.cfg
@@ -2,7 +2,7 @@
 
 numGameThreads = 800
 numNNServerThreadsPerModel = 16
-cudaDeviceToUseThread12 = 3
-cudaDeviceToUseThread13 = 3
-cudaDeviceToUseThread14 = 3
-cudaDeviceToUseThread15 = 3
+deviceToUseThread12 = 3
+deviceToUseThread13 = 3
+deviceToUseThread14 = 3
+deviceToUseThread15 = 3

--- a/configs/compute/5gpu.cfg
+++ b/configs/compute/5gpu.cfg
@@ -2,7 +2,7 @@
 
 numGameThreads = 1000
 numNNServerThreadsPerModel = 20
-cudaDeviceToUseThread16 = 4
-cudaDeviceToUseThread17 = 4
-cudaDeviceToUseThread18 = 4
-cudaDeviceToUseThread19 = 4
+deviceToUseThread16 = 4
+deviceToUseThread17 = 4
+deviceToUseThread18 = 4
+deviceToUseThread19 = 4

--- a/configs/compute/6gpu.cfg
+++ b/configs/compute/6gpu.cfg
@@ -2,7 +2,7 @@
 
 numGameThreads = 1200
 numNNServerThreadsPerModel = 24
-cudaDeviceToUseThread20 = 5
-cudaDeviceToUseThread21 = 5
-cudaDeviceToUseThread22 = 5
-cudaDeviceToUseThread23 = 5
+deviceToUseThread20 = 5
+deviceToUseThread21 = 5
+deviceToUseThread22 = 5
+deviceToUseThread23 = 5

--- a/configs/compute/7gpu.cfg
+++ b/configs/compute/7gpu.cfg
@@ -2,7 +2,7 @@
 
 numGameThreads = 1400
 numNNServerThreadsPerModel = 28
-cudaDeviceToUseThread24 = 6
-cudaDeviceToUseThread25 = 6
-cudaDeviceToUseThread26 = 6
-cudaDeviceToUseThread27 = 6
+deviceToUseThread24 = 6
+deviceToUseThread25 = 6
+deviceToUseThread26 = 6
+deviceToUseThread27 = 6

--- a/configs/compute/8gpu.cfg
+++ b/configs/compute/8gpu.cfg
@@ -2,7 +2,7 @@
 
 numGameThreads = 1600
 numNNServerThreadsPerModel = 32
-cudaDeviceToUseThread28 = 7
-cudaDeviceToUseThread29 = 7
-cudaDeviceToUseThread30 = 7
-cudaDeviceToUseThread31 = 7
+deviceToUseThread28 = 7
+deviceToUseThread29 = 7
+deviceToUseThread30 = 7
+deviceToUseThread31 = 7


### PR DESCRIPTION
## Description

Issue: When running `match`, model 0's threads are spread across all GPUs whereas model 1's threads are all on GPU 0. This probably gives uneven GPU utilization.

Fix: Change the configs so that thread-to-GPU assignments are the same for model 0 and model 1 — use `deviceToUseThreadN` instead of `cudaDeviceToUseModelMThreadN` params. Removing the `cuda` prefix from the param also makes it non-backend specific (i.e., the config should also work for OpenCL or TensorRT)

(This does not affect `victimplay`. The `match` C++ code invokes `initializeNNEvaluators(...)` on two models, which applies `cudaDeviceToUseModel0ThreadN` params to model 0 and `cudaDeviceToUseModel1ThreadN` params to model 1. The `victimplay`/`selfplay` C++ code invokes `initializeNNEvaluator()` on each model individually, hence applying `cudaDeviceToUseModel0ThreadN` to both models.)

## Testing

* Add this line of code to `KataGo-custom` to print out which GPU each thread is assigned to: https://github.com/HumanCompatibleAI/KataGo-custom/pull/36
* Check that threads are assigned across all GPUs for both models on both `match` and `victimplay`