### PR TITLE
baseline_attack: Allow victim to play suicide moves by default

### DIFF
--- a/src/go_attack/baseline_attack.py
+++ b/src/go_attack/baseline_attack.py
@@ -152,7 +152,7 @@ def rollout_policy(
             move_regex = re.compile(r"= ([A-Z][0-9]{1,2}|pass)")
             victim_move = get_msg(move_regex).group(1)
 
-        game.play_move(Move.from_str(victim_move))
+        game.play_move(Move.from_str(victim_move), check_legal=False)
         maybe_print(f"\nTurn {turn}")
         maybe_print(f"KataGo played: {victim_move}")
 


### PR DESCRIPTION
Context: PR #26 made baseline_attack default to not making suicide moves. The rationale was that we want baseline_attack to be able to run against ELF, which does not allow suicide moves. `allow_suicide` was added as a property of `Game`.

Issue: KataGo by default may play suicide moves, and I'm guessing we want to allow that in our transfer experiments despite having baseline_attack avoid suicide moves. But when we run `baseline_attack` with default settings, we'll have `Game.allow_suicide = False`, and `Game.play_move()` will raise an exception upon playing a suicide move from KataGo.

Changes: This PR does the braindead solution of just doing `Game.play_move(check_legal=False)` in baseline_attack for the victim's moves.

The downsides to this change are that if the victim plays a totally invalid move, we won't catch it. I think what this issue reveals is that `allow_suicide` should be a property of `AdversarialPolicy`, not `Game`. I figured I'd open this PR to get feedback from others before spending time implementing that change, though. Another alternative change could be to add an overriding `allow_suicide` argument to `Game.play_move()`.