### PR TITLE
[do not merge] [do not review] match-explorer.ipynb: Modify to analyze predicted win rate/value

### DIFF
--- a/notebooks/match-explorer.ipynb
+++ b/notebooks/match-explorer.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
@@ -36,9 +36,11 @@
     "import dataclasses\n",
     "import os\n",
     "import random\n",
+    "import re\n",
     "from typing import List\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "import pandas as pd\n",
     "from tqdm.auto import tqdm\n",
     "from tqdm.contrib.concurrent import process_map\n",
@@ -57,16 +59,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4ab7a4ef59104cfc9898b38b91049b04",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/1400 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "2500"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "MATCH_DIR = \"../tests/testdata/visits-truncated/\"\n",
-    "# MATCH_DIR = \"/nas/ucb/tony/go-attack/matches/visit-exp3\"\n",
+    "# this should be \"/nas/ucb/ttseng/adv-checkpoints/37-to-61/sgfs\" but I'm testing this on my local machine\n",
+    "MATCH_DIR = \"/Users/t/code/far/adv-checkpoints/37-to-61/sgfs\"\n",
     "\n",
     "sgf_paths = game_info.find_sgf_files(MATCH_DIR)\n",
     "raw_sgf_strs = game_info.read_and_concat_all_files(sgf_paths)\n",
@@ -76,13 +103,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eca6302821b14065aa54492dca27cbb7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/2500 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "random.seed(42)\n",
     "game_infos: List[game_info.GameInfo] = process_map(\n",
@@ -95,13 +137,240 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {
     "pycharm": {
      "name": "#%%\n"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "gtypes: ['normal']\n",
+      "Number of cleanup games: 0\n",
+      "Fraction continuation:     0.0\n",
+      "Fraction used_initial_pos: 0.0\n",
+      "max(init_turn_num)       : 0\n",
+      "CPU times: user 131 ms, sys: 7.75 ms, total: 139 ms\n",
+      "Wall time: 154 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>board_size</th>\n",
+       "      <th>gtype</th>\n",
+       "      <th>start_turn_idx</th>\n",
+       "      <th>init_turn_num</th>\n",
+       "      <th>used_initial_position</th>\n",
+       "      <th>b_name</th>\n",
+       "      <th>w_name</th>\n",
+       "      <th>win_color</th>\n",
+       "      <th>komi</th>\n",
+       "      <th>handicap</th>\n",
+       "      <th>...</th>\n",
+       "      <th>score_rule</th>\n",
+       "      <th>tax_rule</th>\n",
+       "      <th>sui_legal</th>\n",
+       "      <th>has_button</th>\n",
+       "      <th>whb</th>\n",
+       "      <th>fpok</th>\n",
+       "      <th>sgf_str</th>\n",
+       "      <th>lose_color</th>\n",
+       "      <th>win_name</th>\n",
+       "      <th>lose_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>19</td>\n",
+       "      <td>normal</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>bot-cp505-v2</td>\n",
+       "      <td>adv-s56046848-d13775568-v600</td>\n",
+       "      <td>w</td>\n",
+       "      <td>6.5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>AREA</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>(;FF[4]GM[1]SZ[19]PB[bot-cp505-v2]PW[adv-s5604...</td>\n",
+       "      <td>b</td>\n",
+       "      <td>adv-s56046848-d13775568-v600</td>\n",
+       "      <td>bot-cp505-v2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>19</td>\n",
+       "      <td>normal</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>adv-s46847744-d11540675-v600</td>\n",
+       "      <td>bot-cp127-v1</td>\n",
+       "      <td>w</td>\n",
+       "      <td>6.5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>AREA</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>(;FF[4]GM[1]SZ[19]PB[adv-s46847744-d11540675-v...</td>\n",
+       "      <td>b</td>\n",
+       "      <td>bot-cp127-v1</td>\n",
+       "      <td>adv-s46847744-d11540675-v600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>19</td>\n",
+       "      <td>normal</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>bot-cp127-v1</td>\n",
+       "      <td>adv-s55047168-d13516907-v600</td>\n",
+       "      <td>b</td>\n",
+       "      <td>6.5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>AREA</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>(;FF[4]GM[1]SZ[19]PB[bot-cp127-v1]PW[adv-s5504...</td>\n",
+       "      <td>w</td>\n",
+       "      <td>bot-cp127-v1</td>\n",
+       "      <td>adv-s55047168-d13516907-v600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>19</td>\n",
+       "      <td>normal</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>bot-cp127-v1</td>\n",
+       "      <td>adv-s46847744-d11540675-v600</td>\n",
+       "      <td>b</td>\n",
+       "      <td>6.5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>AREA</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>(;FF[4]GM[1]SZ[19]PB[bot-cp127-v1]PW[adv-s4684...</td>\n",
+       "      <td>w</td>\n",
+       "      <td>bot-cp127-v1</td>\n",
+       "      <td>adv-s46847744-d11540675-v600</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>19</td>\n",
+       "      <td>normal</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>bot-cp127-v1</td>\n",
+       "      <td>adv-s40074240-d9782343-v600</td>\n",
+       "      <td>w</td>\n",
+       "      <td>6.5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>...</td>\n",
+       "      <td>AREA</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>True</td>\n",
+       "      <td>False</td>\n",
+       "      <td>0</td>\n",
+       "      <td>False</td>\n",
+       "      <td>(;FF[4]GM[1]SZ[19]PB[bot-cp127-v1]PW[adv-s4007...</td>\n",
+       "      <td>b</td>\n",
+       "      <td>adv-s40074240-d9782343-v600</td>\n",
+       "      <td>bot-cp127-v1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 25 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   board_size   gtype  start_turn_idx  init_turn_num  used_initial_position  \\\n",
+       "0          19  normal               0              0                  False   \n",
+       "1          19  normal               0              0                  False   \n",
+       "2          19  normal               0              0                  False   \n",
+       "3          19  normal               0              0                  False   \n",
+       "4          19  normal               0              0                  False   \n",
+       "\n",
+       "                         b_name                        w_name win_color  komi  \\\n",
+       "0                  bot-cp505-v2  adv-s56046848-d13775568-v600         w   6.5   \n",
+       "1  adv-s46847744-d11540675-v600                  bot-cp127-v1         w   6.5   \n",
+       "2                  bot-cp127-v1  adv-s55047168-d13516907-v600         b   6.5   \n",
+       "3                  bot-cp127-v1  adv-s46847744-d11540675-v600         b   6.5   \n",
+       "4                  bot-cp127-v1   adv-s40074240-d9782343-v600         w   6.5   \n",
+       "\n",
+       "   handicap  ...  score_rule  tax_rule  sui_legal  has_button whb   fpok  \\\n",
+       "0         0  ...        AREA      NONE       True       False   0  False   \n",
+       "1         0  ...        AREA      NONE       True       False   0  False   \n",
+       "2         0  ...        AREA      NONE       True       False   0  False   \n",
+       "3         0  ...        AREA      NONE       True       False   0  False   \n",
+       "4         0  ...        AREA      NONE       True       False   0  False   \n",
+       "\n",
+       "                                             sgf_str  lose_color  \\\n",
+       "0  (;FF[4]GM[1]SZ[19]PB[bot-cp505-v2]PW[adv-s5604...           b   \n",
+       "1  (;FF[4]GM[1]SZ[19]PB[adv-s46847744-d11540675-v...           b   \n",
+       "2  (;FF[4]GM[1]SZ[19]PB[bot-cp127-v1]PW[adv-s5504...           w   \n",
+       "3  (;FF[4]GM[1]SZ[19]PB[bot-cp127-v1]PW[adv-s4684...           w   \n",
+       "4  (;FF[4]GM[1]SZ[19]PB[bot-cp127-v1]PW[adv-s4007...           b   \n",
+       "\n",
+       "                       win_name                     lose_name  \n",
+       "0  adv-s56046848-d13775568-v600                  bot-cp505-v2  \n",
+       "1                  bot-cp127-v1  adv-s46847744-d11540675-v600  \n",
+       "2                  bot-cp127-v1  adv-s55047168-d13516907-v600  \n",
+       "3                  bot-cp127-v1  adv-s46847744-d11540675-v600  \n",
+       "4   adv-s40074240-d9782343-v600                  bot-cp127-v1  \n",
+       "\n",
+       "[5 rows x 25 columns]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "%%time\n",
     "df = pd.DataFrame([gi.to_dict() for gi in game_infos])\n",
@@ -115,6 +384,164 @@
     "print(\"max(init_turn_num)       :\", df.init_turn_num.max())\n",
     "\n",
     "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "];B[]C[0.00 1.00 0.00 -117.3 v=1];W[]C[1.00 0.00 0.00 93.1 v=600 result=W+92.5])\n",
+      "0.00 1.00 0.00 -117.3 v=1     W      1.00 0.00 0.00 93.1 v=600 result=W+92.5\n"
+     ]
+    }
+   ],
+   "source": [
+    "pattern = re.compile(\"C\\\\[([^]]+?)];([BW])\\\\[]C\\\\[([^]]+?)]\\\\)$\")\n",
+    "result = pattern.search(df.iloc[0].sgf_str)\n",
+    "print(df.iloc[0].sgf_str[-80:])\n",
+    "print(result.group(1), \"   \", result.group(2), \"    \", result.group(3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "advs = [\n",
+    " \"adv-s61751296-d15255445-v600\", \n",
+    " \"adv-s60753920-d15021246-v600\",  \n",
+    " \"adv-s59897344-d14761403-v600\",  \n",
+    " \"adv-s59042304-d14514443-v600\",  \n",
+    " \"adv-s58043904-d14307163-v600\",  \n",
+    "]\n",
+    "adv_mask = pd.Series(False, index=df.index)\n",
+    "for adv in advs:\n",
+    "    adv_mask = adv_mask | (df.b_name == adv) | (df.w_name == adv)\n",
+    "victim = \"bot-cp505-v2\"\n",
+    "victim_mask = (df.b_name == victim) | (df.w_name == victim)\n",
+    "filtered_df = df.loc[adv_mask & victim_mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_predictions(sgf: str, adv_color: str):    \n",
+    "    # returns:\n",
+    "    # - victim's prediction for own win rate\n",
+    "    # - victim's prediction for own score\n",
+    "    # - adv's prediction for own win rate\n",
+    "    # - adv's prediction for own score\n",
+    "    # - actual adv score\n",
+    "    #\n",
+    "    # `sgf` should be a game that ends via the victim passing and then the adversary passing\n",
+    "    matches = pattern.search(sgf)\n",
+    "    last_move_color = matches.group(2).lower()\n",
+    "    if last_move_color != adv_color:\n",
+    "        raise Exception(\"WARNING: last_move_color != adv_color\")\n",
+    "    victim_comment = matches.group(1).split()\n",
+    "    adv_comment = matches.group(3).split()\n",
+    "    score_str = adv_comment[-1].replace(\"result=\", \"\")\n",
+    "    white_score = float(score_str[2:]) if score_str[0] == \"W\" else -float(score_str[2:])\n",
+    "    if adv_color == \"b\":\n",
+    "        victim_win_rate = float(victim_comment[0])\n",
+    "        victim_value = float(victim_comment[3])\n",
+    "        adv_win_rate = float(adv_comment[1])\n",
+    "        adv_value = -float(adv_comment[3])\n",
+    "        adv_score = -white_score\n",
+    "    elif adv_color == \"w\":\n",
+    "        victim_win_rate = float(victim_comment[1])\n",
+    "        victim_value = -float(victim_comment[3])\n",
+    "        adv_win_rate = float(adv_comment[0])\n",
+    "        adv_value = float(adv_comment[3])\n",
+    "        adv_score = white_score\n",
+    "    else:\n",
+    "        raise ValueException(f\"unexpected adv_color: {adv_color}\")\n",
+    "    return victim_win_rate, victim_value, adv_win_rate, adv_value, adv_score \n",
+    "    \n",
+    "victim_win_predictions = []\n",
+    "victim_value_predictions = []\n",
+    "adv_win_predictions = []\n",
+    "adv_value_predictions = []\n",
+    "actual_adv_scores = []\n",
+    "for index, game in filtered_df.iterrows():\n",
+    "    adv_color = \"b\" if game.b_name.startswith(\"adv\") else \"w\"\n",
+    "    if adv_color != game.win_color:\n",
+    "        # print(game.sgf_str, \"\\n\\n\")\n",
+    "        continue\n",
+    "    victim_win_rate, victim_value, adv_win_rate, adv_value, adv_score = get_predictions(game.sgf_str, adv_color)\n",
+    "    victim_win_predictions.append(victim_win_rate)\n",
+    "    victim_value_predictions.append(victim_value)\n",
+    "    adv_win_predictions.append(adv_win_rate)\n",
+    "    adv_value_predictions.append(adv_value)\n",
+    "    actual_adv_scores.append(adv_score)\n",
+    "    \n",
+    "# add in stats (which I just manually extracted) for the games where the adversary lost.\n",
+    "# In these games, the game ends by playing to the end, not via passing.\n",
+    "# victim_win_predictions.extend([1., 1., 1.])\n",
+    "# victim_value_predictions.extend([142.8, 260.1, 146.8])\n",
+    "# adv_win_predictions.extend([0., 0., 0.])\n",
+    "# adv_value_predictions.extend([-140.9, -257.7, -143.9])\n",
+    "# actual_adv_scores.extend([-143.5, -257.5, -145.5])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MSE: adv: 1.20198; victim: 50346.86429\n"
+     ]
+    }
+   ],
+   "source": [
+    "victim_value_mse = np.array([(pred + score) ** 2 for pred, score in zip(victim_value_predictions, actual_adv_scores)]).mean()\n",
+    "adv_value_mse = np.array([(pred - score) ** 2 for pred, score in zip(adv_value_predictions, actual_adv_scores)]).mean()\n",
+    "print(f\"MSE: adv: {adv_value_mse:.5f}; victim: {victim_value_mse:.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "num games: 247\n",
+      "adv win rate predictions:  min=0.97000, mean=0.99931, stddev=0.00359)\n",
+      "adv value predictions:  min=40.00000, mean=90.25020, stddev=11.56980)\n",
+      "victim win rate predictions:  min=1.00000, mean=1.00000, stddev=0.00000)\n",
+      "victim value predictions:  min=72.10000, mean=133.86194, stddev=26.90908)\n",
+      "actual adv scores:  min=37.50000, mean=89.52024, stddev=11.66241)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"num games:\", len(adv_win_predictions))\n",
+    "arrs = [\n",
+    "    (\"adv win rate predictions\", adv_win_predictions), \n",
+    "    (\"adv value predictions\", adv_value_predictions),\n",
+    "    (\"victim win rate predictions\", victim_win_predictions), \n",
+    "    (\"victim value predictions\", victim_value_predictions),\n",
+    "    (\"actual adv scores\", actual_adv_scores),\n",
+    "]\n",
+    "for title, arr in arrs:\n",
+    "    arr = np.array(arr)\n",
+    "    print(f\"{title}:  min={arr.min():.5f}, mean={arr.mean():.5f}, stddev={arr.std():.5f})\")"
    ]
   },
   {
@@ -230,7 +657,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.8.2"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Closing this PR immediately — just keeping it as reference in case I want to re-use the changes in the future.

The task:

> One additional analysis that would be nice to perform...: statistical analysis of the victim's and adversary's predicted win rate and value when they pass.
> Basically what you want to look at is for the passes that ended the game, in games for our best adversary (e.g. may want to help yourself to neighboring checkpoints as well if you need >50 games).
> Each move should have an SGF comment of the format C[<white win probability> <black win probability> <tie rate> <value> v=<visit count> w=<weight>]. So we want to look at white/black win probability (depending on the color the agent is playing as) and value, then compute the average {win probability,value} the {victim,adversary} thinks it has when it makes the pass at the end of the game.

What I did:
Filtered games from [this experiment](https://www.notion.so/chaiberkeley/match-evaluating-adversary-checkpoints-from-cp127-to-cp505-4f2d74d682af49bb822112af02521410) by taking games from any of the five adversary checkpoints vs cp505-v1. Then looked at predicted win rates and values.

EDIT 10/31/2022: updated version to include predictions from adversary's penultimate move: https://github.com/HumanCompatibleAI/go_attack/commit/6b9b9e72cacf86d0dc357e21263192ba455203e4
