### PR TITLE
playouts -> visits in baseline_attack; improve Game.to_sgf

### DIFF
--- a/scripts/baseline_attack.py
+++ b/scripts/baseline_attack.py
@@ -48,10 +48,10 @@ def main():  # noqa: D103
         help="Number of games",
     )
     parser.add_argument(
-        "--num-playouts",
+        "--num-visits",
         type=int,
         default=[512],
-        help="Maximum number of MCTS playouts KataGo is allowed to use",
+        help="Maximum number of MCTS visits KataGo is allowed to use",
         nargs="+",
     )
     parser.add_argument("--log-analysis", action="store_true", help="Log analysis")
@@ -150,7 +150,7 @@ def main():  # noqa: D103
         victim=args.victim,
     )
     configs = list(
-        product(model_paths, args.policy, args.num_playouts, args.passing_behavior),
+        product(model_paths, args.policy, args.num_visits, args.passing_behavior),
     )
 
     if len(configs) > 1:

--- a/src/go_attack/baseline_attack.py
+++ b/src/go_attack/baseline_attack.py
@@ -36,7 +36,7 @@ def start_engine(
     executable_path: Path,
     config_path: Path,
     model_path: Path,
-    num_playouts: int,
+    num_visits: int,
     passing_behavior: str,
     gpu: int,
     verbose: bool,
@@ -48,7 +48,7 @@ def start_engine(
         "-model",
         str(model_path),
         "-override-config",
-        f"passingBehavior={passing_behavior},maxPlayouts={num_playouts}",
+        f"passingBehavior={passing_behavior},maxVisits={num_visits}",
         "-config",
         str(config_path),
     ]
@@ -73,13 +73,13 @@ def make_log_dir(
     log_root: Path,
     model_path: Path,
     adversarial_policy: str,
-    num_playouts: int,
+    num_visits: int,
     passing_behavior: str,
 ) -> Path:
     """Make a log directory and return the Path to it."""
     desc = f"model={model_path.stem}"
     desc += f"_policy={adversarial_policy}"
-    desc += f"_playouts={num_playouts}"
+    desc += f"_visits={num_visits}"
     desc += f"_pass={passing_behavior}"
 
     log_dir = log_root / desc
@@ -181,7 +181,7 @@ def rollout_policy(
 def run_baseline_attack(
     model_path: Path,
     adversarial_policy: str,
-    num_playouts: int,
+    num_visits: int,
     passing_behavior: str,
     gpu: Optional[int] = None,
     *,
@@ -219,7 +219,7 @@ def run_baseline_attack(
         executable_path,
         config_path,
         model_path,
-        num_playouts,
+        num_visits,
         passing_behavior,
         gpu,
         verbose,
@@ -231,7 +231,7 @@ def run_baseline_attack(
             log_root,
             model_path,
             adversarial_policy,
-            num_playouts,
+            num_visits,
             passing_behavior,
         )
 


### PR DESCRIPTION
Our baseline attack script had historically set `maxPlayouts` instead of `maxVisits` in the KataGo config, which is inconsistent with all our other code. I noticed this discrepancy before the ICLR deadline and corrected it, so the baseline attack results in the ICLR submission were generated with `maxVisits` and not `maxPlayouts`. This PR will bring this correction to the `main` branch.

While analyzing the baseline attack results, I wanted to use `KataGo-custom/python/summarize_sgfs.py`, but `Game.to_sgf` didn't save the information that `summarize_sgfs.py` expects (such as the actual game result and the names of the players), so I've corrected that here.