### PR TITLE
Add config file for analysis command

### DIFF
--- a/configs/analysis.cfg
+++ b/configs/analysis.cfg
@@ -1,0 +1,57 @@
+# This is on by default in analysis! We definitely don't want this
+conservativePass = false
+maxVisits = 32 # increase this to make victim stronger
+
+# Increase gpu load
+numAnalysisThreads = 1600
+nnMaxBatchSize = 512
+
+# Search limits-----------------------------------------------------------------------------------
+
+numSearchThreads = 1
+
+# Root move selection and biases------------------------------------------------------------------
+
+chosenMoveTemperatureEarly = 0.75
+chosenMoveTemperatureHalflife = 19
+chosenMoveTemperature = 0.15
+chosenMoveSubtract = 0
+chosenMovePrune = 1
+
+rootNoiseEnabled = true
+rootDirichletNoiseTotalConcentration = 10.83
+rootDirichletNoiseWeight = 0.25
+
+rootDesiredPerChildVisitsCoeff = 2
+rootNumSymmetriesToSample = 4
+
+useLcbForSelection = true
+lcbStdevs = 5.0
+minVisitPropForLCB = 0.15
+
+# Internal params---------------------------------------------------------------------------------
+
+winLossUtilityFactor = 1.0
+staticScoreUtilityFactor = 0.00
+dynamicScoreUtilityFactor = 0.40
+dynamicScoreCenterZeroWeight = 0.25
+dynamicScoreCenterScale = 0.50
+noResultUtilityForWhite = 0.0
+drawEquivalentWinsForWhite = 0.5
+
+rootEndingBonusPoints = 0.5
+rootPruneUselessMoves = true
+
+rootPolicyTemperatureEarly = 1.25
+rootPolicyTemperature = 1.1
+
+cpuctExploration = 1.1
+cpuctExplorationLog = 0.0
+fpuReductionMax = 0.2
+rootFpuReductionMax = 0.0
+valueWeightExponent = 0.5
+subtreeValueBiasFactor = 0.35
+subtreeValueBiasWeightExponent = 0.8
+
+mutexPoolSize = 64
+numVirtualLossesPerThread = 1


### PR DESCRIPTION
This PR adds `configs/analysis.cfg` for use with the `katago analysis` command. I copied over `active-experiment.cfg` and then deleted all the config options that KataGo said were unused.

So far we haven't really modified the `analysis` code AFAICT and it doesn't support e.g. EMCTS or pass hardening, but right now we don't need those features. Pass hardening support could be useful soon though.