### PR TITLE
kubernetes: Be able to launch jobs on either CHAI nodes or Lambda nodes

### DIFF
--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -66,7 +66,7 @@ python "$GIT_ROOT"/kubernetes/update_images.py
 export $(grep -v '^#' "$GIT_ROOT"/kubernetes/active-images.env | xargs)
 
 if [ -n "${USE_WEKA}" ]; then
-  VOLUME_FLAGS="--volume-name go-attack --volume-mount shared"
+  VOLUME_FLAGS="--volume-name go-attack --volume-mount /shared"
 else
   VOLUME_FLAGS="--shared-host-dir /nas/ucb/k8/go-attack --shared-host-dir-mount /shared"
 fi


### PR DESCRIPTION
To schedule Hofvarpnir jobs on CHAI nodes, we should use the CHAI NAS directory `/nas/ucb/k8` instead of inaccessible Weka volumes. We should therefore make `kubernetes/launch-job.sh` be able to use either Weka volumes (for scheduling on Lambda nodes) or the CHAI NAS (for scheduling on CHAI nodes).

Changes to `launch-job.sh`
* Use CHAI NAS by default instead of Weka volumes
  * Why:
    * It sounds like we're planning to make the CHAI NAS accessible to all nodes in the future anyway: https://hofvarpnirstudios.slack.com/archives/C03USAVHN0Y/p1666549360555579
    * The KataGo Visualizer can access /nas/ucb already and is not yet set up to access the `go-attack` Weka volume
* Add `--use-weka` flag to make the job use Weka volume instead   


## Testing

* Launch job with `./launch-job.sh --use-weka -g 1 ttseng-foobar-weka`, check that output is in `go-attack` Weka volume
* Launch job with `./launch-job.sh -g 1 ttseng-foobar-nas`, check that output is in `/nas/ucb/k8`
* No `shellcheck` errors