### PR TITLE
kubernetes: Use flag --shared-host-dir-slow-tolerant

### DIFF
--- a/kubernetes/launch-common.sh
+++ b/kubernetes/launch-common.sh
@@ -11,7 +11,7 @@ fi
 if [ -n "${USE_WEKA:-}" ]; then
   export VOLUME_FLAGS="--volume-name go-attack --volume-mount /shared"
 else
-  export VOLUME_FLAGS="--shared-host-dir /nas/ucb/k8/go-attack --shared-host-dir-mount /shared"
+  export VOLUME_FLAGS="--shared-host-dir /nas/ucb/k8/go-attack --shared-host-dir-mount /shared --shared-host-dir-slow-tolerant"
 fi
 
 update_images () {


### PR DESCRIPTION
Changes:
* Use the flag `--shared-host-dir-slow-tolerant` so that jobs can get scheduled on non-CHAI nodes