### PR TITLE
configs/match.cfg: Disable verbose search info

### DIFF
--- a/configs/match.cfg
+++ b/configs/match.cfg
@@ -1,9 +1,6 @@
 @include ../engines/KataGo-raw/cpp/configs/match_example.cfg
 @include amcts/base.cfg
 
-# Useful for debugging etc.
-logSearchInfo = true
-
 # We make komi a constant 6.5, which is the most common komi per
 # https://en.wikipedia.org/wiki/Komi_(Go)
 allowResignation = false


### PR DESCRIPTION
Changes: Disable `logSearchInfo` for `match`. When enabled, `match` prints the board and some search info after every move in every game, which is very verbose. I've only found this useful for seeing the progress of games when there are few games threads and very high visit counts.  