### PR TITLE
kubernetes/train.sh: Clarify that model kind is unused when warmstarting

### DIFF
--- a/kubernetes/train.sh
+++ b/kubernetes/train.sh
@@ -28,8 +28,9 @@ if [ -z "$INITIAL_WEIGHTS" ]; then
     MODEL_KIND=b6c96
 else
     echo "Using initial weights: $INITIAL_WEIGHTS"
-    # shellcheck disable=SC2001
-    MODEL_KIND=$(echo "$INITIAL_WEIGHTS" | sed "s/.*\(b[0-9]\+c[0-9]\+\).*/\1/")
+    # The train script will use the model kind specified by the warmstarted
+    # model's config. MODEL_KIND is ignored.
+    MODEL_KIND="unused"
 
     if [ ! -d "$INITIAL_WEIGHTS" ]; then
         echo "Error: initial weights do not exist: $INITIAL_WEIGHTS"
@@ -78,5 +79,4 @@ else
     fi
 fi
 
-echo "Model kind: $MODEL_KIND"
 ./selfplay/train.sh "$EXPERIMENT_DIR" t0 "$MODEL_KIND" 256 main -disable-vtimeloss -lr-scale "$LR_SCALE" -max-train-bucket-per-new-data 4


### PR DESCRIPTION
Changes:
* `MODEL_KIND` for `train.sh` isn't actually used when warmstarting, and the parsing I wrote to populate `MODEL_KIND` when warmstarting sometimes doesn't work. Let's set `MODEL_KIND` to a dummy value instead. (`MODEL_KIND` is a required argument in our version of KataGo, but it's optional in the latest version of KataGo.)