### PR TITLE
train.sh: Fix crash if warmstart restarts early in training

### DIFF
--- a/kubernetes/train.sh
+++ b/kubernetes/train.sh
@@ -35,9 +35,9 @@ else
         echo "Error: initial weights do not exist: $INITIAL_WEIGHTS"
         exit 1
     fi
-    mkdir -p "$EXPERIMENT_DIR"/train/t0
+    mkdir -p "$EXPERIMENT_DIR"/train/t0/initial_weights
     cp "$INITIAL_WEIGHTS"/saved_model/model.config.json "$EXPERIMENT_DIR"/train/t0/model.config.json
-    cp -r "$INITIAL_WEIGHTS"/saved_model/variables "$EXPERIMENT_DIR"/train/t0/initial_weights
+    cp -r "$INITIAL_WEIGHTS"/saved_model/variables/* "$EXPERIMENT_DIR"/train/t0/initial_weights
 
     if [ -n "${COPY_INITIAL_MODEL:-}" ] &&
        [ ! -f "$EXPERIMENT_DIR"/done-copying-warmstart-model ]; then


### PR DESCRIPTION
Bug:
* Say we have a warmstart training run. `train.sh` copies initial tensorflow weights `$INITIAL_WEIGHTS/saved_model/variables/` to a new directory `"$EXPERIMENT_DIR"/train/t0/initial_weights`.
* If `train.sh` restarts (e.g., due to some scheduling or cluster issue), then the copying occurs again, places the tensorflow weights in `$EXPERIMENT_DIR"/train/t0/initial_weights/variables` (this is incorrect)
* If this occurred before any training had occurred, then once there is enough shuffled data to begin a training epoch, the following error will occur. (This does not happen if some training had already occurred before the restart, since `train.sh` will resume using the trained checkpoints, not `initial_weights`)
```
Traceback (most recent call last):
  File "/engines/KataGo-custom/python/train.py", line 738, in <module>
    estimator.train(
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_estimator/python/estimator/estimator.py", line 370, in train
    loss = self._train_model(input_fn, hooks, saving_listeners)
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_estimator/python/estimator/estimator.py", line 1161, in _train_model
    return self._train_model_default(input_fn, hooks, saving_listeners)
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_estimator/python/estimator/estimator.py", line 1190, in _train_model_default
    estimator_spec = self._call_model_fn(
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_estimator/python/estimator/estimator.py", line 1149, in _call_model_fn
    model_fn_results = self._model_fn(features=features, **kwargs)
  File "/engines/KataGo-custom/python/train.py", line 404, in model_fn
    vars_in_checkpoint = tf.contrib.framework.list_variables(checkpoint_path)
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_core/contrib/framework/python/framework/checkpoint_utils.py", line 93, in list_variables
    reader = load_checkpoint(checkpoint_dir)
  File "/usr/local/lib/python3.8/dist-packages/tensorflow_core/contrib/framework/python/framework/checkpoint_utils.py", line 62, in load_checkpoint
    raise ValueError("Couldn't find 'checkpoint' file or checkpoints in "
ValueError: Couldn't find 'checkpoint' file or checkpoints in given directory /go_attack/scratch/victimplay/run/train/t0/initial_weights/variables
```

Fix: Change `train.sh` to not create `$EXPERIMENT_DIR"/train/t0/initial_weights/variables` if `$EXPERIMENT_DIR"/train/t0/initial_weights` already exists
