### PR TITLE
update_images: Fix network issues when building on Loki

### DIFF
--- a/kubernetes/update_images.py
+++ b/kubernetes/update_images.py
@@ -72,6 +72,7 @@ def main():
                 path=rootdir,
                 dockerfile=f"compose/{prereq}/Dockerfile",
                 tag=f"{REPO_NAME}:{prereq}",
+                network_mode="host",
                 buildargs=BUILD_ARGS,
             )
         print(f"Building {REPO_NAME}:{tag}")
@@ -79,6 +80,7 @@ def main():
             path=rootdir,
             dockerfile=f"compose/{image_type}/Dockerfile",
             tag=image_name,
+            network_mode="host",
             buildargs=BUILD_ARGS,
         )
         # Pylance can't quite figure out the type of build_result; see


### PR DESCRIPTION
Not sure why this started happening, but in the past few weeks I've needed to add the flag `--network=host` to my `docker build` and `docker run` commands on `loki` or else the container has network connectivity. This PR adds the corresponding change to the Docker build commands in `kubernetes/update_images.py`