### PR TITLE
paper_evaluations: Fix NAS path adjustment, update comment on memory usage per net

### DIFF
--- a/scripts/generate_paper_evaluations.py
+++ b/scripts/generate_paper_evaluations.py
@@ -467,7 +467,7 @@ def generate_katago_ckpt_sweep_evaluation(
                 f=f,
                 victims=[
                     {
-                        "path": adjust_nas_path(str(victim_dir / victim)),
+                        "path": adjust_nas_path_custom(str(victim_dir / victim)),
                         "name": victim.lstrip("kata1-").rstrip(".bin.gz"),
                         "visits": parameters["victim_visits"],
                     }

--- a/scripts/paper_evaluations.yml
+++ b/scripts/paper_evaluations.yml
@@ -85,9 +85,9 @@ katago_ckpt_sweep:
   # We compute victim order using the d value.
   victim_start: kata1-b40c256-s11840935168-d2898845681 # cp505
   # Pick the max number of victims that can fit on a GPU.
-  # A b40 net uses about 4GB of GPU memory.
-  # TODO: Calculate how much a b60 net uses
-  # (and how much a b18 net uses if we decide to evaluate against b18 nets).
+  # A b40 net uses 2.2 GB of GPU memory and a b60 net uses 3.1 GB. Upfront costs
+  # including a b6 adversary are 1.8GB. (These numbers drop to 2.1GB, 2.9GB, and
+  # 1.6GB on KataGo v1.12.4. Also, a b18nbt net uses 2.1GB on v1.12.4.)
   n_victims_per_gpu: 8
 
 # Experiment: evaluate adversary vs. victim with varying victim visits.


### PR DESCRIPTION
Updates to `scripts/generate_paper_evaluations.py`:
* Fix: if using the `--run-on-chai` flag, `katago_ckpt_sweep_evaluation` victims should use `/nas/ucb/k8/go-attack/` paths instead of `/shared/` paths
* Fix: I had grossly overestimated the memory footprint of a b40 net because I included the footprint of a b6 adversary plus other fixed memory costs. I've updated a comment in `paper_evaluations.yml` to give more accurate memory footprint measurements.