### PR TITLE
Upgrade to KataGo v1.12.4

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = git@github.com:lightvector/KataGo.git
 [submodule "engines/KataGo-tensorflow"]
 	path = engines/KataGo-tensorflow
-	url = https://github.com/AlignmentResearch/KataGo-custom
+	url = git@github.com:AlignmentResearch/KataGo-custom.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "engines/KataGo-raw"]
 	path = engines/KataGo-raw
 	url = git@github.com:lightvector/KataGo.git
+[submodule "engines/KataGo-tensorflow"]
+	path = engines/KataGo-tensorflow
+	url = https://github.com/AlignmentResearch/KataGo-custom

--- a/compose/python/Dockerfile
+++ b/compose/python/Dockerfile
@@ -46,6 +46,7 @@ ARG ARG_GIT_COMMIT
 ENV GIT_COMMIT=$ARG_GIT_COMMIT
 # Copy over KataGo python files
 COPY ./engines/KataGo-raw/python /engines/KataGo-raw/python
+COPY ./engines/KataGo-tensorflow/python /engines/KataGo-tensorflow/python
 COPY ./engines/KataGo-custom/python /engines/KataGo-custom/python
 
 COPY ./configs/ /go_attack/configs
@@ -57,6 +58,12 @@ COPY ./setup.py /go_attack/setup.py
 # Make /engines/KataGo-* git repos to make scripts run nicely.
 # TODO: Make this less hacky...
 WORKDIR /engines/KataGo-raw
+RUN git init . \
+  && git add . \
+  && git config user.name dummy_name \
+  && git config user.email dummy@email.com \
+  && git commit -m "Dummy commit"
+WORKDIR /engines/KataGo-tensorflow
 RUN git init . \
   && git add . \
   && git config user.name dummy_name \

--- a/compose/python/requirements.txt
+++ b/compose/python/requirements.txt
@@ -4,6 +4,7 @@
 psutil
 requests_toolbelt
 scipy
+sgfmill
 torch
 
 # Helpful libraries

--- a/compose/python/requirements.txt
+++ b/compose/python/requirements.txt
@@ -2,7 +2,9 @@
 
 # Libs needed by KataGo
 psutil
+requests_toolbelt
 scipy
+torch
 
 # Helpful libraries
 gpustat

--- a/compose/python/requirements.txt
+++ b/compose/python/requirements.txt
@@ -4,7 +4,6 @@
 psutil
 requests_toolbelt
 scipy
-sgfmill
 torch
 
 # Helpful libraries

--- a/configs/amcts/base.cfg
+++ b/configs/amcts/base.cfg
@@ -6,7 +6,9 @@ numBots = 2
 botName0 = victim
 maxVisits0 = 1
 searchAlgorithm0 = MCTS
+useGraphSearch0 = true
 
 botName1 = adversary
-maxVisits1 = 200
+maxVisits1 = 600
 searchAlgorithm1 = AMCTS
+useGraphSearch1 = false

--- a/configs/amcts/victimplay.cfg
+++ b/configs/amcts/victimplay.cfg
@@ -12,10 +12,12 @@ numBots = 2
 # victim
 maxVisits0 = 1 # victim
 searchAlgorithm0 = MCTS
+useGraphSearch0 = true
 
 # adversary
 maxVisits1 = 600
 searchAlgorithm1 = AMCTS
+useGraphSearch1 = false
 
 # other options
 useAuxPolicyTarget = true

--- a/configs/gtp-amcts.cfg
+++ b/configs/gtp-amcts.cfg
@@ -17,10 +17,14 @@ useGraphSearch1 = true
 # This is set to 6 in the original gtp_example.cfg but A-MCTS only supports numSearchThreads = 1
 numSearchThreads = 1
 
+# conservativePass is "a good idea when using [the bot] for analysis or playing
+# on servers where scoring may be implemented non-tromp-taylorly", but we don't
+# care about this and are only trying to win under Tromp-Taylor rules.
+conservativePass = false
 # If we want to keep behavior close to KataGo v1.10, consider setting the
 # following parameters:
-# valueWeightExponent0 = 0.5
-# subtreeValueBiasFactor0 = 0.35
-# subtreeValueBiasWeightExponent0 = 0.8
-# fpuParentWeightByVisitedPolicy0 = false
-# enablePassingHacks0 = false
+# valueWeightExponent = 0.5
+# subtreeValueBiasFactor = 0.35
+# subtreeValueBiasWeightExponent = 0.8
+# fpuParentWeightByVisitedPolicy = false
+# enablePassingHacks = false

--- a/configs/gtp-amcts.cfg
+++ b/configs/gtp-amcts.cfg
@@ -8,9 +8,19 @@ numBots = 2
 
 maxVisits0 = 600
 searchAlgorithm0 = AMCTS
+useGraphSearch0 = false
 
 maxVisits1 = 32
 searchAlgorithm1 = MCTS
+useGraphSearch1 = true
 
 # This is set to 6 in the original gtp_example.cfg but A-MCTS only supports numSearchThreads = 1
 numSearchThreads = 1
+
+# If we want to keep behavior close to KataGo v1.10, consider setting the
+# following parameters:
+# valueWeightExponent0 = 0.5
+# subtreeValueBiasFactor0 = 0.35
+# subtreeValueBiasWeightExponent0 = 0.8
+# fpuParentWeightByVisitedPolicy0 = false
+# enablePassingHacks0 = false

--- a/configs/gtp-base.cfg
+++ b/configs/gtp-base.cfg
@@ -27,10 +27,3 @@ ponderingEnabled = false
 # searchFactorAfterTwoPass = 0.25
 # searchFactorWhenWinning = 0.40
 # searchFactorWhenWinningThreshold = 0.95
-
-# conservativePass has a bug that makes the bot weaker to passing-based attacks.
-# We should merge commits up to
-# https://github.com/lightvector/KataGo/commit/eea5d0cbc3909ef55b81b364b19593d83f7aefa8
-# (committed on Jan 11 2023) into KataGo-custom before setting conservativePass
-# to true.
-conservativePass = false

--- a/configs/gtp-raw.cfg
+++ b/configs/gtp-raw.cfg
@@ -4,10 +4,3 @@
 
 maxVisits = 32
 numSearchThreads = 6    # Default from gtp_example.cfg
-
-# conservativePass is on by default in GTP, but we'll enable conservativePass
-# only for KataGo-raw until KataGo-custom merges in the conservativePass bugfix
-# from commit
-# https://github.com/lightvector/KataGo/commit/eea5d0cbc3909ef55b81b364b19593d83f7aefa8)
-# (committed on Jan 11 2023).
-conservativePass = true

--- a/configs/kgs-bot/adversary_bot.cfg
+++ b/configs/kgs-bot/adversary_bot.cfg
@@ -120,7 +120,7 @@ numBots = 2
 maxVisits0 = 600
 searchAlgorithm0 = AMCTS
 useGraphSearch0 = false
-# Params to keep behavior similar to KataGo v1.10, upon which the cyclic
+# Params to keep behavior similar to KataGo v1.10, using which the cyclic
 # adversary was trained.
 valueWeightExponent0 = 0.5
 subtreeValueBiasFactor0 = 0.35

--- a/configs/kgs-bot/adversary_bot.cfg
+++ b/configs/kgs-bot/adversary_bot.cfg
@@ -120,17 +120,19 @@ numBots = 2
 maxVisits0 = 600
 searchAlgorithm0 = AMCTS
 useGraphSearch0 = false
-# Params to keep behavior similar to KataGo v1.10, using which the cyclic
-# adversary was trained.
-valueWeightExponent0 = 0.5
-subtreeValueBiasFactor0 = 0.35
-subtreeValueBiasWeightExponent0 = 0.8
-fpuParentWeightByVisitedPolicy0 = false
-enablePassingHacks0 = false
 
 maxVisits1 = 1
 searchAlgorithm1 = MCTS
 useGraphSearch1 = true
+
+# Params to keep behavior similar to KataGo v1.10, using which the cyclic
+# adversary was trained.
+conservativePass = false
+valueWeightExponent = 0.5
+subtreeValueBiasFactor = 0.35
+subtreeValueBiasWeightExponent = 0.8
+fpuParentWeightByVisitedPolicy = false
+enablePassingHacks = false
 
 # If provided, limit maximum number of new playouts per search to this much. (With tree reuse, playouts do not count earlier search)
 # maxPlayouts = 300

--- a/configs/kgs-bot/adversary_bot.cfg
+++ b/configs/kgs-bot/adversary_bot.cfg
@@ -125,9 +125,9 @@ maxVisits1 = 1
 searchAlgorithm1 = MCTS
 useGraphSearch1 = true
 
+conservativePass = false
 # Params to keep behavior similar to KataGo v1.10, using which the cyclic
 # adversary was trained.
-conservativePass = false
 valueWeightExponent = 0.5
 subtreeValueBiasFactor = 0.35
 subtreeValueBiasWeightExponent = 0.8

--- a/configs/kgs-bot/adversary_bot.cfg
+++ b/configs/kgs-bot/adversary_bot.cfg
@@ -119,9 +119,18 @@ numBots = 2
 
 maxVisits0 = 600
 searchAlgorithm0 = AMCTS
+useGraphSearch0 = false
+# Params to keep behavior similar to KataGo v1.10, upon which the cyclic
+# adversary was trained.
+valueWeightExponent0 = 0.5
+subtreeValueBiasFactor0 = 0.35
+subtreeValueBiasWeightExponent0 = 0.8
+fpuParentWeightByVisitedPolicy0 = false
+enablePassingHacks0 = false
 
 maxVisits1 = 1
 searchAlgorithm1 = MCTS
+useGraphSearch1 = true
 
 # If provided, limit maximum number of new playouts per search to this much. (With tree reuse, playouts do not count earlier search)
 # maxPlayouts = 300

--- a/configs/match.cfg
+++ b/configs/match.cfg
@@ -36,6 +36,7 @@ chosenMoveTemperatureEarly = 0.50
 rootSymmetryPruning = true
 antiMirror = true
 fillDameBeforePass = true
+enablePassingHacks = true
 # TODO(tomtseng): conservativePass  has a bug that sometimes makes the bot weaker
 # to passing-based attacks. We should merge commits up to
 # https://github.com/lightvector/KataGo/commit/eea5d0cbc3909ef55b81b364b19593d83f7aefa8

--- a/configs/sabaki/gtp-adv600-vm1-s.cfg
+++ b/configs/sabaki/gtp-adv600-vm1-s.cfg
@@ -9,6 +9,7 @@ searchAlgorithm1 = MCTS
 
 numSearchThreads = 1
 
+conservativePass = false
 # Params to keep behavior similar to KataGo v1.10, using which the cyclic
 # adversary was trained.
 valueWeightExponent = 0.5

--- a/configs/sabaki/gtp-adv600-vm1-s.cfg
+++ b/configs/sabaki/gtp-adv600-vm1-s.cfg
@@ -3,7 +3,16 @@
 numBots = 2
 maxVisits0 = 600
 searchAlgorithm0 = AMCTS-S
+useGraphSearch0 = false
 maxVisits1 = 1
 searchAlgorithm1 = MCTS
 
 numSearchThreads = 1
+
+# Params to keep behavior similar to KataGo v1.10, using which the cyclic
+# adversary was trained.
+valueWeightExponent = 0.5
+subtreeValueBiasFactor = 0.35
+subtreeValueBiasWeightExponent = 0.8
+fpuParentWeightByVisitedPolicy = false
+enablePassingHacks = false

--- a/kubernetes/shuffle-and-export.sh
+++ b/kubernetes/shuffle-and-export.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-cd /engines/KataGo-custom/python
+cd /engines/KataGo-tensorflow/python
 RUN_NAME="$1"
 DIRECTORY="$2"
 VOLUME_NAME="$3"

--- a/kubernetes/train.sh
+++ b/kubernetes/train.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-cd /engines/KataGo-custom/python
+cd /engines/KataGo-tensorflow/python
 
 # Command line flag parsing (https://stackoverflow.com/a/33826763/4865149).
 # Flags must be specified before positional arguments.

--- a/scripts/generate_paper_evaluations.py
+++ b/scripts/generate_paper_evaluations.py
@@ -143,12 +143,14 @@ def write_bot(
     extra_parameters: Iterable[Mapping[str, str]] = {},
 ) -> None:
     """Writes bot config parameters to file `f`."""
+    use_graph_search = bot_algorithm == "MCTS"
     f.write(
         f"""\
 nnModelFile{bot_index} = {bot_path}
 botName{bot_index} = {bot_name}
 maxVisits{bot_index} = {num_visits}
 searchAlgorithm{bot_index} = {bot_algorithm}
+useGraphSearch{bot_index} = {str(use_graph_search).lower()}
 """,
     )
     for param in extra_parameters:

--- a/scripts/paper_evaluations.yml
+++ b/scripts/paper_evaluations.yml
@@ -85,9 +85,8 @@ katago_ckpt_sweep:
   # We compute victim order using the d value.
   victim_start: kata1-b40c256-s11840935168-d2898845681 # cp505
   # Pick the max number of victims that can fit on a GPU.
-  # A b40 net uses 2.2 GB of GPU memory and a b60 net uses 3.1 GB. Upfront costs
-  # including a b6 adversary are 1.8GB. (These numbers drop to 2.1GB, 2.9GB, and
-  # 1.6GB on KataGo v1.12.4. Also, a b18nbt net uses 2.1GB on v1.12.4.)
+  # A b40 net uses 2.1 GB of GPU memory, a b60 net uses 2.9 GB, and a b18nbt net
+  # uses 2.1GB. Upfront costs including a b6 adversary are 1.6GB.
   n_victims_per_gpu: 8
 
 # Experiment: evaluate adversary vs. victim with varying victim visits.


### PR DESCRIPTION
Update `KataGo-custom` to v1.12.4.

Model training still uses TF so that we can finetune our TF cyclic adversary. If we want to finetune the new architectures  using PyTorch model training, we'll need to further edit kubernetes/train.sh since some of the flags to train.py have changed (e.g., model kind is a flag -model-kind instead of a positional argument, and warmstarting is done with the -initial-checkpoint flag instead of done by copying files into a initial_weights directory). `kubernetes/shuffle_and_export.sh` would need to switch to using the PyTorch code as well, since the `shuffleddata` format is different between TF and PyTorch.