### PR TITLE
kubernetes+config: Update config values

### DIFF
--- a/configs/amcts/components/board-sizes.cfg
+++ b/configs/amcts/components/board-sizes.cfg
@@ -1,7 +1,7 @@
 # Which board sizes we play on.
 
 bSizes = 7,8,9,10,11,12,13,14,15,16,17,18,19
-bSizeRelProbs = 1,1,4,2,3,4,10,6,7,8,9,10,35
+bSizeRelProbs = 1,1,4,2,3,4,10,6,7,8,9,10,75
 allowRectangleProb = 0.00
 
 maxMovesPerGame = 1600

--- a/configs/compute/1gpu.cfg
+++ b/configs/compute/1gpu.cfg
@@ -18,7 +18,7 @@ nnRandomize = true
 # cudaDeviceToUseModel0Thread0 = 3 #use device 3 for model 0, server thread 0
 # cudaDeviceToUseModel0Thread1 = 2 #use device 2 for model 0, server thread 1
 
-deviceToUseThread0 = 1
+deviceToUseThread0 = 0
 
 useFP16 = true
 # We only set NHWC for CUDA because TensorRT requires useNHWC == false.

--- a/configs/compute/1gpu.cfg
+++ b/configs/compute/1gpu.cfg
@@ -1,14 +1,14 @@
-numGameThreads = 256
+numGameThreads = 32
 
 # GPU Settings-------------------------------------------------------------------------------
 # 1xA6000
 # 2 sockets of AMD EPYC 7763 64-Core Processors = 128 physical cores
 #                                                 each core has 2 threads
 
-nnMaxBatchSize = 256
+nnMaxBatchSize = 32
 nnCacheSizePowerOfTwo = 24
 nnMutexPoolSizePowerOfTwo = 18
-numNNServerThreadsPerModel = 4
+numNNServerThreadsPerModel = 1
 nnRandomize = true
 
 # CUDA GPU settings--------------------------------------
@@ -18,10 +18,7 @@ nnRandomize = true
 # cudaDeviceToUseModel0Thread0 = 3 #use device 3 for model 0, server thread 0
 # cudaDeviceToUseModel0Thread1 = 2 #use device 2 for model 0, server thread 1
 
-deviceToUseThread0 = 0
-deviceToUseThread1 = 0
-deviceToUseThread2 = 0
-deviceToUseThread3 = 0
+deviceToUseThread0 = 1
 
 useFP16 = true
 # We only set NHWC for CUDA because TensorRT requires useNHWC == false.

--- a/configs/compute/2gpu.cfg
+++ b/configs/compute/2gpu.cfg
@@ -1,8 +1,3 @@
 @include 1gpu.cfg
 
-numGameThreads = 400
-numNNServerThreadsPerModel = 8
-deviceToUseThread4 = 1
-deviceToUseThread5 = 1
-deviceToUseThread6 = 1
-deviceToUseThread7 = 1
+numGameThreads = 64

--- a/configs/compute/3gpu.cfg
+++ b/configs/compute/3gpu.cfg
@@ -1,8 +1,3 @@
 @include 2gpu.cfg
 
-numGameThreads = 600
-numNNServerThreadsPerModel = 12
-deviceToUseThread8 = 2
-deviceToUseThread9 = 2
-deviceToUseThread10 = 2
-deviceToUseThread11 = 2
+numGameThreads = 96

--- a/configs/compute/4gpu.cfg
+++ b/configs/compute/4gpu.cfg
@@ -1,8 +1,3 @@
 @include 3gpu.cfg
 
-numGameThreads = 800
-numNNServerThreadsPerModel = 16
-deviceToUseThread12 = 3
-deviceToUseThread13 = 3
-deviceToUseThread14 = 3
-deviceToUseThread15 = 3
+numGameThreads = 128

--- a/configs/compute/5gpu.cfg
+++ b/configs/compute/5gpu.cfg
@@ -1,8 +1,3 @@
 @include 4gpu.cfg
 
-numGameThreads = 1000
-numNNServerThreadsPerModel = 20
-deviceToUseThread16 = 4
-deviceToUseThread17 = 4
-deviceToUseThread18 = 4
-deviceToUseThread19 = 4
+numGameThreads = 160

--- a/configs/compute/6gpu.cfg
+++ b/configs/compute/6gpu.cfg
@@ -1,8 +1,3 @@
 @include 5gpu.cfg
 
-numGameThreads = 1200
-numNNServerThreadsPerModel = 24
-deviceToUseThread20 = 5
-deviceToUseThread21 = 5
-deviceToUseThread22 = 5
-deviceToUseThread23 = 5
+numGameThreads = 192

--- a/configs/compute/7gpu.cfg
+++ b/configs/compute/7gpu.cfg
@@ -1,8 +1,3 @@
 @include 6gpu.cfg
 
-numGameThreads = 1400
-numNNServerThreadsPerModel = 28
-deviceToUseThread24 = 6
-deviceToUseThread25 = 6
-deviceToUseThread26 = 6
-deviceToUseThread27 = 6
+numGameThreads = 224

--- a/configs/compute/8gpu.cfg
+++ b/configs/compute/8gpu.cfg
@@ -1,8 +1,3 @@
 @include 7gpu.cfg
 
-numGameThreads = 1600
-numNNServerThreadsPerModel = 32
-deviceToUseThread28 = 7
-deviceToUseThread29 = 7
-deviceToUseThread30 = 7
-deviceToUseThread31 = 7
+numGameThreads = 256

--- a/kubernetes/launch-baseline-attack.sh
+++ b/kubernetes/launch-baseline-attack.sh
@@ -3,7 +3,7 @@
 DEFAULT_NUM_GPUS=4
 
 usage() {
-  echo "Usage: $0 [--gpus GPUS] [--games NUM_GAMES] [--use-weka] PREFIX"
+  echo "Usage: $0 [--gpus GPUS] [--games NUM_GAMES] PREFIX"
   echo
   echo "positional arguments:"
   echo "  PREFIX     Identifying label used for the name of the job and the name"
@@ -13,9 +13,6 @@ usage() {
   echo "  -g GPUS, --gpus GPUS"
   echo "    Number of GPUs to use."
   echo "    default: ${DEFAULT_NUM_GPUS}"
-  echo "  -w, --use-weka"
-  echo "    Store results on the go-attack Weka volume instead of the CHAI NAS"
-  echo "    volume."
   echo
   echo "Optional arguments should be specified before positional arguments."
 }
@@ -26,7 +23,6 @@ while [ -n "${1-}" ]; do
   case $1 in
     -h|--help) usage; exit 0 ;;
     -g|--gpus) NUM_GPUS=$2; shift ;;
-    -w|--use-weka) export USE_WEKA=1 ;;
     *) break ;;
   esac
   shift

--- a/kubernetes/launch-common.sh
+++ b/kubernetes/launch-common.sh
@@ -8,11 +8,7 @@ if [ "$(git status --porcelain --untracked-files=no | wc -l)" -gt 0 ]; then
     exit 1
 fi
 
-if [ -n "${USE_WEKA:-}" ]; then
-  export VOLUME_FLAGS="--volume-name go-attack --volume-mount /shared"
-else
-  export VOLUME_FLAGS="--shared-host-dir /nas/ucb/k8/go-attack --shared-host-dir-mount /shared --shared-host-dir-slow-tolerant"
-fi
+export VOLUME_FLAGS="--volume-name go-attack --volume-mount /shared"
 
 update_images () {
   # Maybe build and push new Docker images

--- a/kubernetes/launch-gtp-eval.sh
+++ b/kubernetes/launch-gtp-eval.sh
@@ -88,6 +88,7 @@ update_images cpp-and-twogtp
 # having games run sequentially quickly instead of games run in parallel slowly.
 # If we run slow games in parallel, we're likely to lose a lot of progress if
 # the job gets interrupted.
+# Job name is prefixed with "gg", meaning "go-gtp".
 # shellcheck disable=SC2086
 ctl job run --container \
   "$CPP_AND_TWOGTP_IMAGE" \
@@ -99,5 +100,5 @@ ctl job run --container \
   --high-priority \
   --gpu "$NUM_GPUS" \
   --cpu "$NUM_CPUS" \
-  --name "go-gtp-$1" \
+  --name "gg-$1" \
   --replicas 1

--- a/kubernetes/launch-gtp-eval.sh
+++ b/kubernetes/launch-gtp-eval.sh
@@ -100,5 +100,6 @@ ctl job run --container \
   --high-priority \
   --gpu "$NUM_GPUS" \
   --cpu "$NUM_CPUS" \
+  --memory 72Gi \
   --name "gg-$1" \
   --replicas 1

--- a/kubernetes/launch-gtp-eval.sh
+++ b/kubernetes/launch-gtp-eval.sh
@@ -14,10 +14,6 @@ usage() {
   echo "Schedules a job that plays a victim (on KataGo-raw) against an A-MCTS"
   echo "adversary via GTP."
   echo
-  echo "Results are stored on the go-attack Weka volume by default. On the NAS,"
-  echo "twogtp hits the following error:"
-  echo "  Could not lock file '/shared/gtp-eval/test-20230120-140920/sgfs/game.lock': Input/output error"
-  echo
   echo "Usage: $0 [--cpus CPUS] [--gpus GPUS] [--games NUM_GAMES]"
   echo "         [--adv-config ADV_CONFIG] [--victim-config VICTIM_CONFIG]"
   echo "         [--adv-config ADV_MODEL] [--victim-config VICTIM_MODEL] PREFIX"
@@ -84,7 +80,6 @@ fi
 RUN_NAME="$1-$(date +%Y%m%d-%H%M%S)"
 echo "Run name: $RUN_NAME"
 
-export USE_WEKA=1
 source "$(dirname "$(readlink -f "$0")")"/launch-common.sh
 update_images cpp-and-twogtp
 

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -199,7 +199,7 @@ ctl job run --container \
     "$CURRICULUM_CMD" \
     --high-priority \
     --restart-on-failure \
-    --memory 72Gi 16Gi 72Gi 100Gi 4Gi \
+    --memory 72Gi 16Gi 72Gi 96Gi 4Gi \
     --gpu 1 1 1 0 0 \
     --name gt-"$1"-v \
     --replicas "${MIN_VICTIMPLAY_GPUS}" 1 1 1 1

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -18,7 +18,7 @@ usage() {
   echo "          [--lr-scale LR_SCALE] [--predictor]"
   echo "          [--predictor-warmstart-ckpt CHECKPOINT] [--resume TIMESTAMP]"
   echo "          [--warmstart-ckpt CHECKPOINT] [--victim-ckpt CHECKPOINT]"
-  echo "          [--use-weka] PREFIX"
+  echo "          PREFIX"
   echo
   echo "positional arguments:"
   echo "  PREFIX  Identifying label used for the name of the job and the name"
@@ -56,8 +56,7 @@ usage() {
   echo "    Resume a previous run. If this flag is given, the PREFIX argument"
   echo "    must exactly be match the run to be resumed, and the TIMESTAMP"
   echo "    argument should match the timestamp attached to the name of the"
-  echo "    previous run's output directory. The use of the --use-weka flag"
-  echo "    must also exactly match that of the previous run."
+  echo "    previous run's output directory."
   echo "  --warmstart-ckpt CHECKPOINT"
   echo "    Path to checkpoint's TF weights directory to use for warmstarting"
   echo "    the adversary, e.g.,"
@@ -71,9 +70,6 @@ usage() {
   echo "    weights directory for the last victim (i.e., the bot not"
   echo "    being trained) in the initial iteration's curriculum (CURRICULUM,"
   echo "    or ALTERNATE_CURRICULUM if --alternate-iteration-first is set)."
-  echo "  -w, --use-weka"
-  echo "    Store results on the go-attack Weka volume instead of the CHAI NAS"
-  echo "    volume."
   echo
   echo "Optional arguments should be specified before positional arguments."
   echo
@@ -111,7 +107,6 @@ while [ -n "${1-}" ]; do
     -r|--resume) RESUME_TIMESTAMP=$2; shift ;;
     --warmstart-ckpt) WARMSTART_CKPT=$2; shift ;;
     --victim-ckpt) VICTIM_CKPT=$2; shift ;;
-    -w|--use-weka) export USE_WEKA=1 ;;
     -*) echo "Unknown parameter passed: $1"; usage; exit 1 ;;
     *) break ;;
   esac

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -214,6 +214,8 @@ if [ "$USE_GATING" -eq 1 ]; then
       $VOLUME_FLAGS \
       --command "/go_attack/kubernetes/gatekeeper.sh $RUN_NAME $VOLUME_NAME" \
       --high-priority \
+      --restart-on-failure \
+      --memory 32Gi \
       --gpu 1 \
       --name gt-"$1"-g \
       --replicas 1

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -215,7 +215,7 @@ if [ "$USE_GATING" -eq 1 ]; then
       --command "/go_attack/kubernetes/gatekeeper.sh $RUN_NAME $VOLUME_NAME" \
       --high-priority \
       --restart-on-failure \
-      --memory 32Gi \
+      --memory 48Gi \
       --gpu 1 \
       --name gt-"$1"-g \
       --replicas 1

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -198,6 +198,8 @@ ctl job run --container \
     "$SHUFFLE_AND_EXPORT_CMD" \
     "$CURRICULUM_CMD" \
     --high-priority \
+    --restart-on-failure \
+    --memory 72Gi 16Gi 72Gi 100Gi 4Gi \
     --gpu 1 1 1 0 0 \
     --name gt-"$1"-v \
     --replicas "${MIN_VICTIMPLAY_GPUS}" 1 1 1 1
@@ -224,6 +226,8 @@ if [ $EXTRA_VICTIMPLAY_GPUS -gt 0 ]; then
       "$CPP_IMAGE" \
       $VOLUME_FLAGS \
       --command "$VICTIMPLAY_CMD" \
+      --restart-on-failure \
+      --memory 72Gi \
       --gpu 1 \
       --name gt-"$1"-e \
       --replicas "${EXTRA_VICTIMPLAY_GPUS}"

--- a/kubernetes/launch-match.sh
+++ b/kubernetes/launch-match.sh
@@ -9,7 +9,7 @@ DEFAULT_NUM_GPUS=1
 usage() {
   echo "Schedules a job that runs \`match\`."
   echo
-  echo "Usage: $0 [--gpus GPUS] [--games NUM_GAMES] [--use-weka] [--subdir SUBDIR] PREFIX"
+  echo "Usage: $0 [--gpus GPUS] [--games NUM_GAMES] [--subdir SUBDIR] PREFIX"
   echo "          [--EXTRA_MATCH_FLAGS]"
   echo
   echo "positional arguments:"
@@ -24,9 +24,6 @@ usage() {
   echo "    Number of match games to play. If not specified, then the number of"
   echo "    games will be the numGamesTotal specified in the \`match\` config"
   echo "    multiplied by the number of GPUs."
-  echo "  -w, --use-weka"
-  echo "    Store results on the go-attack Weka volume instead of the CHAI NAS"
-  echo "    volume."
   echo "  -s, --subdir SUBDIR"
   echo "    Subdirectory of the output directory to store the results in."
   echo
@@ -47,7 +44,6 @@ while true; do
     -g|--gpus) NUM_GPUS=$2; shift ;;
     -n|--games) NUM_GAMES=$2; shift ;;
     -s|--subdir) SUBDIR=$2; shift ;;
-    -w|--use-weka) export USE_WEKA=1 ;;
     *) break ;;
   esac
   shift

--- a/kubernetes/launch-match.sh
+++ b/kubernetes/launch-match.sh
@@ -83,6 +83,7 @@ else
   GAMES_PER_REPLICA=-1
 fi
 
+# Job name is prefixed with "gm", meaning "go-match".
 # shellcheck disable=SC2086
 ctl job run --container \
   "$CPP_IMAGE" \
@@ -94,6 +95,6 @@ ctl job run --container \
   $*" \
   --high-priority \
   --gpu 1 \
-  --name go-match-"$PREFIX" \
+  --name gm-"$PREFIX" \
   --replicas "${NUM_GPUS}"
 exit 0

--- a/kubernetes/launch-match.sh
+++ b/kubernetes/launch-match.sh
@@ -94,6 +94,7 @@ ctl job run --container \
   ${GAMES_PER_REPLICA}
   $*" \
   --high-priority \
+  --memory 64Gi \
   --gpu 1 \
   --name gm-"$PREFIX" \
   --replicas "${NUM_GPUS}"

--- a/kubernetes/launch-match.sh
+++ b/kubernetes/launch-match.sh
@@ -94,7 +94,7 @@ ctl job run --container \
   ${GAMES_PER_REPLICA}
   $*" \
   --high-priority \
-  --memory 64Gi \
+  --memory 100Gi \
   --gpu 1 \
   --name gm-"$PREFIX" \
   --replicas "${NUM_GPUS}"


### PR DESCRIPTION
Update some config/param values that I've used in most of my jobs recently:
* Increase the proportion of 19x19 games to the same proportion KataGo uses in its later runs (53.6%) (we care most about 19x19 games so this seems reasonable to me)
* Reduce `numGameThreads`—this matters for victimplay, since if `numGameThreads` is high and the number of victimplay workers is high, then there will be a lot of stale games still in flight when we move on to a later model checkpoint
* Always use Weka volume: we've copied `/nas/` data to the Weka volume so let's just default to using the Weka volume
* Shorten job names boilerplate: Hofvarpnir now appends the user's Slack member ID to pod names so now we only have 38 characters for custom job names rather than 50. Let's shorten "go-train-JOBNAME-vital" to "gt-JOBNAME-v"
* Set memory limits: Hofvarpnir now defaults to giving pods a memory limit of 16Gi, which isn't enough for some of our pods. We need to specify higher memory limits.