### PR TITLE
configs: Increase game threads, decrease cache size

### DIFF
--- a/configs/compute/1gpu.cfg
+++ b/configs/compute/1gpu.cfg
@@ -1,13 +1,13 @@
-numGameThreads = 32
+numGameThreads = 128
 
 # GPU Settings-------------------------------------------------------------------------------
 # 1xA6000
 # 2 sockets of AMD EPYC 7763 64-Core Processors = 128 physical cores
 #                                                 each core has 2 threads
 
-nnMaxBatchSize = 32
-nnCacheSizePowerOfTwo = 24
-nnMutexPoolSizePowerOfTwo = 18
+nnMaxBatchSize = 128
+nnCacheSizePowerOfTwo = 21
+nnMutexPoolSizePowerOfTwo = 17
 numNNServerThreadsPerModel = 1
 nnRandomize = true
 

--- a/configs/compute/2gpu.cfg
+++ b/configs/compute/2gpu.cfg
@@ -1,3 +1,3 @@
 @include 1gpu.cfg
 
-numGameThreads = 64
+numGameThreads = 256

--- a/configs/compute/3gpu.cfg
+++ b/configs/compute/3gpu.cfg
@@ -1,3 +1,3 @@
 @include 2gpu.cfg
 
-numGameThreads = 96
+numGameThreads = 384

--- a/configs/compute/4gpu.cfg
+++ b/configs/compute/4gpu.cfg
@@ -1,3 +1,3 @@
 @include 3gpu.cfg
 
-numGameThreads = 128
+numGameThreads = 512

--- a/configs/compute/5gpu.cfg
+++ b/configs/compute/5gpu.cfg
@@ -1,3 +1,3 @@
 @include 4gpu.cfg
 
-numGameThreads = 160
+numGameThreads = 640

--- a/configs/compute/6gpu.cfg
+++ b/configs/compute/6gpu.cfg
@@ -1,3 +1,3 @@
 @include 5gpu.cfg
 
-numGameThreads = 192
+numGameThreads = 768

--- a/configs/compute/7gpu.cfg
+++ b/configs/compute/7gpu.cfg
@@ -1,3 +1,3 @@
 @include 6gpu.cfg
 
-numGameThreads = 224
+numGameThreads = 896

--- a/configs/compute/8gpu.cfg
+++ b/configs/compute/8gpu.cfg
@@ -1,3 +1,3 @@
 @include 7gpu.cfg
 
-numGameThreads = 256
+numGameThreads = 1024

--- a/configs/match-1gpu.cfg
+++ b/configs/match-1gpu.cfg
@@ -1,2 +1,2 @@
-@include compute/1gpu.cfg
 @include match.cfg
+@include compute/1gpu.cfg


### PR DESCRIPTION
Changes:
* Increase default numGameThreads per GPU from 32 to 128. 
  * We had decreased numGameThreads from 256 to 32 out of concern that during victimplay, having high game threads would mean we would have a lot of lagging games from previous models. But setting numGameThreads = 16 gave much less game throughput, even though GPU utilization looked high from `nvidia-smi`.
  * Based on a crude benchmark, numGameThreads should be 128+ for high game throughput: https://www.notion.so/chaiberkeley/debugging-victimplay-throughput-being-lower-than-expected-bc376db69a5a4343bd6c609dcec1ca4b?pvs=4#82543a2589c348d3ae3940584fd72abf
* Decrease cache size `nnCacheSizePowerOfTwo` from 24 to 21. Each cache size entry is 1.5KB so this decreases cache size per net from 25GB to 3GB. 
  * Flamingo nodes' memory is not large enough to allow 25GB per net
  * I also decreased nnMutexPoolSizePowerOfTwo to 17 because the default setting of nnMutexPoolSizePowerOfTwo given by KataGo's benchmark.cpp is `nnCacheSizePowerOfTwo - 4`.
* In `match-1gpu.cfg`, put `1gpu.cfg` after `match.cfg` in the `@include` list so that `1gpu.cfg`'s threads and cache params will take precedence