### PR TITLE
configs: Set v1.10 params properly

### DIFF
--- a/configs/gtp-amcts.cfg
+++ b/configs/gtp-amcts.cfg
@@ -19,8 +19,8 @@ numSearchThreads = 1
 
 # If we want to keep behavior close to KataGo v1.10, consider setting the
 # following parameters:
-# valueWeightExponent0 = 0.5
-# subtreeValueBiasFactor0 = 0.35
-# subtreeValueBiasWeightExponent0 = 0.8
-# fpuParentWeightByVisitedPolicy0 = false
-# enablePassingHacks0 = false
+# valueWeightExponent = 0.5
+# subtreeValueBiasFactor = 0.35
+# subtreeValueBiasWeightExponent = 0.8
+# fpuParentWeightByVisitedPolicy = false
+# enablePassingHacks = false

--- a/configs/kgs-bot/adversary_bot.cfg
+++ b/configs/kgs-bot/adversary_bot.cfg
@@ -120,6 +120,11 @@ numBots = 2
 maxVisits0 = 600
 searchAlgorithm0 = AMCTS
 useGraphSearch0 = false
+
+maxVisits1 = 1
+searchAlgorithm1 = MCTS
+useGraphSearch1 = true
+
 # Params to keep behavior similar to KataGo v1.10, using which the cyclic
 # adversary was trained.
 valueWeightExponent = 0.5
@@ -127,10 +132,6 @@ subtreeValueBiasFactor = 0.35
 subtreeValueBiasWeightExponent = 0.8
 fpuParentWeightByVisitedPolicy = false
 enablePassingHacks = false
-
-maxVisits1 = 1
-searchAlgorithm1 = MCTS
-useGraphSearch1 = true
 
 # If provided, limit maximum number of new playouts per search to this much. (With tree reuse, playouts do not count earlier search)
 # maxPlayouts = 300

--- a/configs/kgs-bot/adversary_bot.cfg
+++ b/configs/kgs-bot/adversary_bot.cfg
@@ -122,11 +122,11 @@ searchAlgorithm0 = AMCTS
 useGraphSearch0 = false
 # Params to keep behavior similar to KataGo v1.10, using which the cyclic
 # adversary was trained.
-valueWeightExponent0 = 0.5
-subtreeValueBiasFactor0 = 0.35
-subtreeValueBiasWeightExponent0 = 0.8
-fpuParentWeightByVisitedPolicy0 = false
-enablePassingHacks0 = false
+valueWeightExponent = 0.5
+subtreeValueBiasFactor = 0.35
+subtreeValueBiasWeightExponent = 0.8
+fpuParentWeightByVisitedPolicy = false
+enablePassingHacks = false
 
 maxVisits1 = 1
 searchAlgorithm1 = MCTS


### PR DESCRIPTION
We upgraded from KataGo v1.10 to v1.11 with Nora's Nov 2022 merge PR, and there were some params that changed between v1.10 and v1.11. I noted in some config files with params need to be changed to get close to v1.10 behavior. 

This PR modifies the params in GTP files so that they affect both the bot and the bot being simulated in AMCTS (e.g., params were changed from `fpuParentWeightByVisitedPolicy0` to `fpuParentWeightByVisitedPolicy`). Based on some GTP evaluations I had been running, I believe this actually does make a difference in win rate / behavior with our cyclic/pass adversaries, though unfortunately I deleted the data from those evaluations since I didn't think that the data was notable at the time.