### PR TITLE
Adjust Sabaki config params to account for KataGo v1.11 

### DIFF
--- a/configs/sabaki/gtp-adv600-vm1-s.cfg
+++ b/configs/sabaki/gtp-adv600-vm1-s.cfg
@@ -3,7 +3,16 @@
 numBots = 2
 maxVisits0 = 600
 searchAlgorithm0 = AMCTS-S
+useGraphSearch0 = false
 maxVisits1 = 1
 searchAlgorithm1 = MCTS
 
 numSearchThreads = 1
+
+# Params to keep behavior similar to KataGo v1.10, using which the cyclic
+# adversary was trained.
+valueWeightExponent = 0.5
+subtreeValueBiasFactor = 0.35
+subtreeValueBiasWeightExponent = 0.8
+fpuParentWeightByVisitedPolicy = false
+enablePassingHacks = false


### PR DESCRIPTION
After updating to KataGo v1.11, we needed to reset some config params to match old v1.10 params that the cyclic adversary was trained on: https://github.com/AlignmentResearch/go_attack/blob/b4305ccf2e296d74b142c34c18b782f2f54baf48/configs/kgs-bot/adversary_bot.cfg#L130-L134

This PR copies those config params to the Sabaki config as well.