### PR TITLE
active-experiment: Remove compute params, add comment on LCB

### DIFF
--- a/configs/active-experiment.cfg
+++ b/configs/active-experiment.cfg
@@ -1,7 +1,7 @@
 # Must be combined with a config file from the compute/ folder to work
 @include amcts/victimplay.cfg
 
-maxVisits0 = 32 # increase this to make victim stronger, though usually this is overridden by the curriculum
+maxVisits0 = 32 # increase this to make victim stronger, though if the curriculum script is running then it'll override this
 # Uncomment this for pass-hardening
 # passingBehavior0 = avoid-pass-alive-territory
 

--- a/configs/active-experiment.cfg
+++ b/configs/active-experiment.cfg
@@ -1,10 +1,13 @@
 # Must be combined with a config file from the compute/ folder to work
 @include amcts/victimplay.cfg
 
-maxVisits0 = 32 # increase this to make victim stronger
+maxVisits0 = 32 # increase this to make victim stronger, though usually this is overridden by the curriculum
 # Uncomment this for pass-hardening
 # passingBehavior0 = avoid-pass-alive-territory
 
-# Increase gpu load
-numGameThreads = 1600
-nnMaxBatchSize = 512
+# LCB is turned off for selfplay since lightvector found that LCB make training
+# progress slightly worse, though LCB makes eval much stronger:
+# https://lifein19x19.com/viewtopic.php?p=278323#p278323
+# For victimplay it's a bit disconcerting to see a large train/eval gap, so we
+# may want to re-enable LCB, or at least enable LCB for the victim.
+# useLcbForSelfplayMove = true


### PR DESCRIPTION
Edits to active-experiment.cfg:
* Edit comment on `maxVisits0` to remark that it's usually overridden by the curriculum
* Remove compute params since those are covered by `compute/1gpu.cfg`
* Add note on `useLcbForSelfplayMove`