### PR TITLE
shuffle-and-export: Add flag for pre-seeding data

### DIFF
--- a/kubernetes/iterated-training/shuffle-and-export.sh
+++ b/kubernetes/iterated-training/shuffle-and-export.sh
@@ -11,8 +11,7 @@ while true; do
   echo "Starting iteration $ITERATION"
 
   ITERATION_DIR=/"$VOLUME_NAME"/victimplay/"$RUN_NAME"/iteration-"$ITERATION"
-  USE_GATING=0
   run_until_curriculum_done "$ITERATION_DIR" \
     /go_attack/kubernetes/shuffle-and-export.sh "$RUN_NAME"-"$ITERATION" \
-    "$RUN_NAME"/iteration-"$ITERATION" "$VOLUME_NAME" "$USE_GATING"
+    "$RUN_NAME"/iteration-"$ITERATION" "$VOLUME_NAME"
 done

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -176,6 +176,13 @@ if [ -n "${USE_ITERATED_TRAINING:-}" ]; then
     echo "--victim-ckpt must be specified for iterated training."
     exit 1
   fi
+  # This is not hard to implement, but it's not a priority right now since we
+  # haven't used this script for automated iterated training in a while.
+  echo "Warning: Iterated training works better when each attack "`
+    `"iteration is pre-seeded with data from the previous attack iteration, "`
+    `"and similarly for each defense iteration. This is not yet implemented"`
+    `"in these automated iterated training scripts."
+
   VICTIMPLAY_CMD="/go_attack/kubernetes/iterated-training/victimplay.sh $VICTIMPLAY_FLAGS $RUN_NAME $VOLUME_NAME $ALTERNATE_ITERATION_FIRST"
   EVALUATE_LOOP_CMD="/go_attack/kubernetes/iterated-training/evaluate_loop.sh $RUN_NAME $VOLUME_NAME $ALTERNATE_ITERATION_FIRST"
   TRAIN_CMD="/go_attack/kubernetes/iterated-training/train.sh $TRAIN_FLAGS $RUN_NAME $VOLUME_NAME $LR_SCALE $VICTIM_CKPT"

--- a/kubernetes/launch-job.sh
+++ b/kubernetes/launch-job.sh
@@ -165,6 +165,11 @@ else
   VICTIMPLAY_FLAGS=""
   TRAIN_FLAGS=""
 fi
+if [ -n "${USE_GATING:-}" ]; then
+  SHUFFLE_FLAGS="--gating"
+else
+  SHUFFLE_FLAGS=""
+fi
 
 if [ -n "${USE_ITERATED_TRAINING:-}" ]; then
   if [ -z "${VICTIM_CKPT:-}" ]; then
@@ -180,7 +185,7 @@ else
   VICTIMPLAY_CMD+=" $VICTIMPLAY_FLAGS $RUN_NAME $VOLUME_NAME"
   EVALUATE_LOOP_CMD="/engines/KataGo-custom/cpp/evaluate_loop.sh $PREDICTOR_FLAG /$VOLUME_NAME/victimplay/$RUN_NAME /$VOLUME_NAME/victimplay/$RUN_NAME/eval"
   TRAIN_CMD="/go_attack/kubernetes/train.sh $TRAIN_FLAGS $RUN_NAME $VOLUME_NAME $LR_SCALE"
-  SHUFFLE_AND_EXPORT_CMD="/go_attack/kubernetes/shuffle-and-export.sh $RUN_NAME $RUN_NAME $VOLUME_NAME $USE_GATING"
+  SHUFFLE_AND_EXPORT_CMD="/go_attack/kubernetes/shuffle-and-export.sh $SHUFFLE_FLAGS $RUN_NAME $RUN_NAME $VOLUME_NAME"
   CURRICULUM_CMD="/go_attack/kubernetes/curriculum.sh $RUN_NAME $VOLUME_NAME $CURRICULUM"
 fi
 

--- a/kubernetes/shuffle-and-export.sh
+++ b/kubernetes/shuffle-and-export.sh
@@ -9,8 +9,8 @@ while [ -n "${1-}" ]; do
     --gating) USE_GATING=1 ;;
     # Pre-seed with this training data as the source.
     # If the pre-seed source directory is formatted as `*/selfplay/t0-s*-d*`,
-    # then all earlier directories with lower step count in `*/selfplay/` will
-    # also be included in the pre-seeding
+    # then all earlier directories with lower step count (s) in `*/selfplay/`
+    # will also be included in the pre-seeding.
     --preseed) PRESEED_SRC=$2; shift ;;
     -*) echo "Unknown parameter passed: $1"; usage; exit 1 ;;
     *) break ;;
@@ -29,11 +29,12 @@ shift
 /go_attack/kubernetes/log-git-commit.sh /"$VOLUME_NAME"/victimplay/"$DIRECTORY"
 
 EXPERIMENT_DIR=/"$VOLUME_NAME"/victimplay/"$DIRECTORY"
-mkdir --parents "$EXPERIMENT_DIR"
+mkdir --parents "$EXPERIMENT_DIR"/selfplay
 
 PRESEED_DST="$EXPERIMENT_DIR"/selfplay/prev-selfplay
 if [ -n "${PRESEED_SRC:-}" ] && [ ! -d "$PRESEED_DST" ]; then
   PRESEED_SRC=$(realpath "$PRESEED_SRC")
+  echo "$PRESEED_SRC" > "$EXPERIMENT_DIR"/selfplay/prev-selfplay-$(date +%Y%m%d-%H%M%S).log
   if [[ "$PRESEED_SRC" =~ -s([0-9]+)-d[0-9]+ ]]; then
     # Preseed data up to the step count listed in PRESEED_SRC.
     FINAL_STEP=${BASH_REMATCH[1]}
@@ -58,5 +59,5 @@ if [ -n "${PRESEED_SRC:-}" ] && [ ! -d "$PRESEED_DST" ]; then
 fi
 
 cd /engines/KataGo-custom/python
-./selfplay/shuffle_and_export_loop.sh "$RUN_NAME" "$EXPERIMENT_DIR" /tmp 16 256 $USE_GATING $@
+./selfplay/shuffle_and_export_loop.sh "$RUN_NAME" "$EXPERIMENT_DIR" /tmp 16 256 $USE_GATING "$@"
 sleep infinity

--- a/kubernetes/shuffle-and-export.sh
+++ b/kubernetes/shuffle-and-export.sh
@@ -1,14 +1,61 @@
-#!/bin/bash -e
-cd /engines/KataGo-custom/python
+#!/bin/bash -eu
+
+USE_GATING=0
+# Command line flag parsing (https://stackoverflow.com/a/33826763/4865149).
+# Flags must be specified before positional arguments.
+while [ -n "${1-}" ]; do
+  case $1 in
+    # Set this flag if the gatekeeper is enabled.
+    --gating) USE_GATING=1 ;;
+    # Set this to preseed training data with data up to and including this
+    # directory. This should be a */selfplay/t0-s*-d* directory.
+    --preseed) PRESEED_SRC=$2; shift ;;
+    -*) echo "Unknown parameter passed: $1"; usage; exit 1 ;;
+    *) break ;;
+  esac
+  shift
+done
+
 RUN_NAME="$1"
 DIRECTORY="$2"
 VOLUME_NAME="$3"
-# 1 to enable gatekeeper, 0 to disable gatekeeper
-USE_GATING="$4"
+shift
+shift
+shift
 
 # not related to shuffle-and-export but we want some process to log this
 /go_attack/kubernetes/log-git-commit.sh /"$VOLUME_NAME"/victimplay/"$DIRECTORY"
 
-mkdir -p /"$VOLUME_NAME"/victimplay/"$DIRECTORY"
-./selfplay/shuffle_and_export_loop.sh    "$RUN_NAME"    /"$VOLUME_NAME"/victimplay/"$DIRECTORY"    /tmp    16    256    $USE_GATING
+EXPERIMENT_DIR=/"$VOLUME_NAME"/victimplay/"$DIRECTORY"
+mkdir --parents "$EXPERIMENT_DIR"
+
+PRESEED_DST="$EXPERIMENT_DIR"/selfplay/prev-selfplay
+if [ -n "${PRESEED_SRC:-}" ] && [ ! -d "$PRESEED_DST" ]; then
+  if [[ "$PRESEED_SRC" =~ t0-s([0-9]+)-d[0-9]+ ]]; then
+    FINAL_STEP=${BASH_REMATCH[1]}
+  else
+    echo "Can't parse step count from $PRESEED_SRC"
+    exit 1
+  fi
+
+  mkdir --parents "$PRESEED_DST"
+  PRESEED_SRC=$(realpath "$PRESEED_SRC")
+  PRESEED_SRC_PARENT=$(dirname "$PRESEED_SRC")
+  for DIR in "$PRESEED_SRC_PARENT"/*/; do
+    DIR_NAME=$(basename "$DIR")
+    if [ "$DIR_NAME" = "prev-selfplay" ] || [ "$DIR_NAME" = "random" ]; then
+      ln -s "$DIR" "$PRESEED_DST"
+    elif [[ "$DIR" =~ t0-s([0-9]+)-d[0-9]+ ]]; then
+      STEP=${BASH_REMATCH[1]}
+      if [ "$STEP" -le "$FINAL_STEP" ]; then
+        ln -s "$DIR" "$PRESEED_DST"
+      fi
+    else
+      echo "Skipping unrecognized pre-seed source: $DIR"
+    fi
+  done
+fi
+
+cd /engines/KataGo-custom/python
+./selfplay/shuffle_and_export_loop.sh "$RUN_NAME" "$EXPERIMENT_DIR" /tmp 16 256 $USE_GATING $@
 sleep infinity


### PR DESCRIPTION
Changes to `kubernetes/shuffle-and-export.sh`:
* Add command-line flag for preseeding data with data from a previous run. We found that this was needed to make warm-starting runs train well.
* Move the gatekeeper parameter to be a command-line flag as well
* Pass extra arguments of `kubernetes/shuffle-and-export.sh` onto `KataGo-custom/python/selfplay/shuffle_and_export_loop.sh` — this is useful for passing flags to adjust the shuffler window size