### PR TITLE
scripts: Add script for deleting old `shuffleddata` directories

### DIFF
--- a/scripts/prune_shuffleddata.py
+++ b/scripts/prune_shuffleddata.py
@@ -1,8 +1,8 @@
 """Deletes old shuffleddata directories to clear up space."""
+import argparse
+import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
-
-from tqdm import tqdm
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Delete old shuffleddata directories")
@@ -15,7 +15,7 @@ if __name__ == "__main__":
         "--since-days",
         type=int,
         default=1,
-        description="shuffledata not modified since this number of days will be deleted",
+        description="shuffledata not modified since this many days will be deleted",
     )
     args = parser.parse_args()
     victimplay_dir = args.victimplay_dir
@@ -25,12 +25,12 @@ if __name__ == "__main__":
     dirs_to_delete = []
     dirs_to_keep = []
     now = datetime.now()
-    max_age_allowed = now - timedelta(days=days)
-    for child_dir in tqdm(victimplay_dir.rglob("shuffleddata/")):
+    oldest_date_allowed = now - timedelta(days=days)
+    for child_dir in victimplay_dir.rglob("shuffleddata/"):
         if child_dir.is_symlink():
             continue
         mod_time = datetime.fromtimestamp(child_dir.stat().st_mtime)
-        if mod_time < max_age_allowed:
+        if mod_time < oldest_date_allowed:
             dirs_to_delete.append(child_dir)
         else:
             dirs_to_keep.append(child_dir)
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     confirm = input("Confirm file deletions (y/n): ")
 
     if confirm.lower().startswith("y"):
-        for data_dir in tdqm(dirs_to_delete):
+        for data_dir in dirs_to_delete:
             shutil.rmtree(data_dir)
     else:
         print("Deletions canceled")

--- a/scripts/prune_shuffleddata.py
+++ b/scripts/prune_shuffleddata.py
@@ -36,10 +36,10 @@ if __name__ == "__main__":
             dirs_to_keep.append(child_dir)
 
     # Confirm with user that the deletions look correct.
-    print("The following shuffleddata dirs will be deleted:")
+    print("The following shuffleddata directories will be deleted:")
     for file in dirs_to_delete:
         print(file)
-    print("\nThe following shuffleddata dirs will be kept:")
+    print("\nThe following shuffleddata directories will be kept:")
     for file in dirs_to_keep:
         print(file)
     confirm = input("Confirm file deletions (y/n): ")

--- a/scripts/prune_shuffleddata.py
+++ b/scripts/prune_shuffleddata.py
@@ -9,13 +9,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "victimplay_dir",
         type=Path,
-        description="Path in which which to recursively search for shuffleddata",
+        help="Path in which which to recursively search for shuffleddata",
     )
     parser.add_argument(
         "--since-days",
         type=int,
         default=1,
-        description="shuffledata not modified since this many days will be deleted",
+        help="shuffledata not modified since this many days will be deleted",
     )
     args = parser.parse_args()
     victimplay_dir = args.victimplay_dir

--- a/scripts/prune_shuffleddata.py
+++ b/scripts/prune_shuffleddata.py
@@ -1,0 +1,51 @@
+"""Deletes old shuffleddata directories to clear up space."""
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from tqdm import tqdm
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Delete old shuffleddata directories")
+    parser.add_argument(
+        "victimplay_dir",
+        type=Path,
+        description="Path in which which to recursively search for shuffleddata",
+    )
+    parser.add_argument(
+        "--since-days",
+        type=int,
+        default=1,
+        description="shuffledata not modified since this number of days will be deleted",
+    )
+    args = parser.parse_args()
+    victimplay_dir = args.victimplay_dir
+    days = args.since_days
+
+    # Find all shuffleddata files recursively.
+    dirs_to_delete = []
+    dirs_to_keep = []
+    now = datetime.now()
+    max_age_allowed = now - timedelta(days=days)
+    for child_dir in tqdm(victimplay_dir.rglob("shuffleddata/")):
+        if child_dir.is_symlink():
+            continue
+        mod_time = datetime.fromtimestamp(child_dir.stat().st_mtime)
+        if mod_time < max_age_allowed:
+            dirs_to_delete.append(child_dir)
+        else:
+            dirs_to_keep.append(child_dir)
+
+    # Confirm with user that the deletions look correct.
+    print("The following shuffleddata dirs will be deleted:")
+    for file in dirs_to_delete:
+        print(file)
+    print("\nThe following shuffleddata dirs will be kept:")
+    for file in dirs_to_keep:
+        print(file)
+    confirm = input("Confirm file deletions (y/n): ")
+
+    if confirm.lower().startswith("y"):
+        for data_dir in tdqm(dirs_to_delete):
+            shutil.rmtree(data_dir)
+    else:
+        print("Deletions canceled")


### PR DESCRIPTION
Our volume on flamingo was getting full, so I wrote this script to delete old `shuffledata` directories. It freed up 1.5T of disk usage.