### PR TITLE
C++ Dockerfile: Remove pin of libc version number

### DIFF
--- a/compose/cpp/Dockerfile
+++ b/compose/cpp/Dockerfile
@@ -13,13 +13,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Update Nvidia signing key
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 
-# Add focal-proposed for libc6 patch
-# See https://wiki.ubuntu.com/Testing/EnableProposed for details.
-RUN echo "deb http://archive.ubuntu.com/ubuntu focal-proposed main" >> /etc/apt/sources.list \
- && echo "Package: *"                                               >> /etc/apt/preferences \
- && echo "Pin: release a=focal-proposed"                            >> /etc/apt/preferences \
- && echo "Pin-Priority: 400"                                        >> /etc/apt/preferences
-
 # Install apt packages
 RUN apt-get update -q \
   && apt-get install -y \
@@ -38,11 +31,6 @@ RUN apt-get update -q \
   libssl-dev \
   libzip-dev \
   zlib1g-dev \
-  # Newer version of glibc without a deadlock bug:
-  # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1899800
-  libc6=2.31-0ubuntu9.9 \
-  libc6-dev=2.31-0ubuntu9.9 \
-  libc-dev-bin=2.31-0ubuntu9.9 \
   # Clean up
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
@@ -81,13 +69,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Update Nvidia signing key
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 
-# Add focal-proposed for libc6 patch
-# See https://wiki.ubuntu.com/Testing/EnableProposed for details.
-RUN echo "deb http://archive.ubuntu.com/ubuntu focal-proposed main" >> /etc/apt/sources.list \
- && echo "Package: *"                                               >> /etc/apt/preferences \
- && echo "Pin: release a=focal-proposed"                            >> /etc/apt/preferences \
- && echo "Pin-Priority: 400"                                        >> /etc/apt/preferences
-
 # Install useful apt packages
 RUN apt-get update -q \
   && apt-get install -y \
@@ -114,9 +95,6 @@ RUN apt-get update -q \
   libssl1.1 \
   libzip5 \
   zlib1g \
-  # Newer version of glibc without a deadlock bug:
-  # https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1899800
-  libc6=2.31-0ubuntu9.9 \
   # Clean up
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Previously we pinned libc6 to version 2.31. This no longer works, with the following error on `apt install`:
```
E: Version '2.31-0ubuntu9.9' for 'libc6' was not found
E: Version '2.31-0ubuntu9.9' for 'libc6-dev' was not found
E: Version '2.31-0ubuntu9.9' for 'libc-dev-bin' was not found
```
I removed the pin, rebuilt the image, and checked the `libc` version installed via `ldd --version`. The version is `2.31-0ubuntu9.12`, so I think we're safe to stop forcing the version.