### PR TITLE
scripts: Add script for generating heat map visualizations of cyclic group captures

### DIFF
--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -302,8 +302,7 @@ def main():
         if capture_data is None:
             # It's not necessarily a problem if we do not detect a cyclic
             # capture. The victim may have resigned, or in match and victimplay,
-            # the game can end due to BoardHistory::endGameIfAllPassAlive()
-            # firing in KataGo's play.cpp.
+            # the game can end due to BoardHistory::endGameIfAllPassAlive().
             continue
 
         num_cycles += 1

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -37,9 +37,9 @@ def get_cycle_interior(cyclic_group: np.ndarray) -> np.ndarray:
     Returns:
         Boolean map of points inside the cyclic group.
     """
+    ADJACENCIES = [[0, -1], [0, 1], [-1, 0], [1, 0]]
     visited = np.zeros_like(cyclic_group, dtype=bool)
     interior = ~cyclic_group
-    adjacencies = [[0, -1], [0, 1], [-1, 0], [1, 0]]
     x_max, y_max = cyclic_group.shape
 
     # Any point that has a path that reaches the edge of the board without
@@ -195,7 +195,6 @@ def main():
                         victim_heatmap += victim_stones
                         interior_adversary_heatmap += interior_adversary_stones
                         interior_victim_heatmap += interior_victim_stones
-
                         break
 
     fig, axs = plt.subplots(3, 2)

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -4,8 +4,7 @@ import itertools
 import re
 from pathlib import Path
 
-import matplotlib.cm
-import matplotlib.colors
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 from tqdm import tqdm
@@ -195,7 +194,7 @@ def main():
 
     fig, axs = plt.subplots(3, 2)
 
-    color_map = matplotlib.cm.get_cmap("hot")
+    color_map = matplotlib.colormaps.get_cmap("hot")
     normalizer = matplotlib.colors.Normalize(vmin=0, vmax=1)
 
     def plot_data(figure_row, figure_column, data, title):

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -17,7 +17,7 @@ CAPTURE_GROUP_SIZE_THRESHOLD = 20
 
 # Substrings that appear uniquely in adversaries' and victims' names and are
 # used to identify which player is the adversary.
-ADVERSARY_NAME_SUBSTRINGS = ["adv"]
+ADVERSARY_NAME_SUBSTRINGS = ["adv", "attack"] + [f"r{i}-v600" for i in range(10)]
 VICTIM_NAME_SUBSTRINGS = ["victim", "b18-"]
 
 
@@ -106,7 +106,7 @@ def main():
             sgf_files = itertools.chain(path.glob("**/*.sgf"), path.glob("**/*.sgfs"))
 
         for sgf_file in tqdm(list(sgf_files), leave=False):
-            for sgf_string in tqdm(open(sgf_file), leave=False):
+            for sgf_string in tqdm(open(sgf_file).readlines(), leave=False):
 
                 # Filter for games with the correct board size and with the
                 # adversary winning.

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -181,11 +181,11 @@ def get_cyclic_capture(
         if len(interior_points[0]) == 0:
             continue
 
-        # To get rid of some symmetries, flip cyclic group that its center is in
-        # the top-left corner, and flip across the diagonal if the center's row
-        # coordinate is larger than the column coordinate.
+        # To get rid of some symmetries, flip cyclic group so that its center is
+        # in the top-left corner, and flip across the diagonal if the center's
+        # row coordinate is larger than the column coordinate.
         # (It's ambiguous which symmetry to use when the center lies upon an
-        # axis of reflection---we don't try to handle this.)
+        # axis of reflection. We don't attempt to handle this.)
         interior_centroid = np.average(interior.nonzero(), axis=1)
         for axis, coord in enumerate(interior_centroid):
             if coord > BOARD_LEN / 2:

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -1,4 +1,5 @@
 """Plots cycle shapes captured in adversarial Go games."""
+
 import argparse
 import itertools
 import re

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -94,7 +94,7 @@ def main():
     parser.add_argument(
         "--output",
         type=Path,
-        help="Output file. If not specified, the plot will be shown aand not saved.",
+        help="Output file. If not specified, the plot will be shown and not saved.",
     )
     args = parser.parse_args()
 

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -1,5 +1,4 @@
-DESCRIPTION = """Plots cycle shapes captured in adversarial Go games."""
-
+"""Plots cycle shapes captured in adversarial Go games."""
 import argparse
 import itertools
 import re
@@ -21,18 +20,21 @@ VICTIM_NAME_SUBSTRINGS = ["victim", "b18-"]
 
 
 def get_sgf_property(property_name: str, sgf_string: str) -> str:
-    return re.search(f"{property_name}\[([^\]]+)\]", sgf_string).group(1)
+    """Returns the value of a property in an SGF string."""
+    match = re.search(rf"{property_name}\[([^\]]+)\]", sgf_string)
+    assert match is not None, f"No property {property_name} in SGF string {sgf_string}"
+    return match.group(1)
 
 
-def get_cycle_interior(cyclic_group: np.ndarray) -> (np.ndarray, (int, int)):
-    """Returns boolean map of points inside cyclic group.
+def get_cycle_interior(cyclic_group: np.ndarray) -> np.ndarray:
+    """Gets board points inside a cyclic group.
 
-    Args
-    ----
-    cyclic_group:
-      Boolean map of cyclic group points.
+    Args:
+        cyclic_group: Boolean map of cyclic group points.
+
+    Returns:
+        Boolean map of points inside the cyclic group.
     """
-
     visited = np.zeros_like(cyclic_group, dtype=bool)
     interior = ~cyclic_group
     adjacencies = [[0, -1], [0, 1], [-1, 0], [1, 0]]
@@ -73,7 +75,8 @@ def get_cycle_interior(cyclic_group: np.ndarray) -> (np.ndarray, (int, int)):
 
 
 def main():
-    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    """Script entrypoint."""
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "files",
         type=Path,
@@ -135,7 +138,7 @@ def main():
                 game = Game.from_sgf(sgf_string)
 
                 for i, (prev_board, board) in enumerate(
-                    zip(game.board_states, game.board_states[1:])
+                    zip(game.board_states, game.board_states[1:]),
                 ):
                     player_color = Color.BLACK if i % 2 == 0 else Color.WHITE
                     if player_color != adversary_color:
@@ -197,16 +200,16 @@ def main():
         return im
 
     plot_data(0, 0, cycle_heatmap, "Cyclic group")
-    axs[0, 1].axis("off") # Unused plot space
+    axs[0, 1].axis("off")  # Unused plot space
     plot_data(1, 0, adversary_heatmap, "Adversary stones")
     plot_data(1, 1, interior_adversary_heatmap, "Interior adversary stones")
     plot_data(2, 0, victim_heatmap, "Victim stones")
     im = plot_data(2, 1, interior_victim_heatmap, "Interior victim stones")
     for _, ax in np.ndenumerate(axs):
-        ax.set_xticks(range(0, board.shape[0], 5))
-        ax.set_yticks(range(0, board.shape[1], 5))
-        ax.set_xticks(range(board.shape[0]), minor=True)
-        ax.set_yticks(range(board.shape[1]), minor=True)
+        ax.set_xticks(range(0, BOARD_LEN, 5))
+        ax.set_yticks(range(0, BOARD_LEN, 5))
+        ax.set_xticks(range(BOARD_LEN), minor=True)
+        ax.set_yticks(range(BOARD_LEN), minor=True)
         ax.xaxis.set_ticks_position("both")
         ax.yaxis.set_ticks_position("both")
     fig.suptitle(f"{args.title}, sample size of {num_cycles}")

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -128,6 +128,9 @@ def main():
                         num_cycles += 1
                         interior = get_cycle_interior(captured_stones)
 
+                        interior_points = interior.nonzero()
+                        if len(interior_points[0]) == 0:
+                            continue
                         # Flip cyclic group so that it's in the top-left corner
                         interior_centroid = np.average(interior.nonzero(), axis=1)
                         for axis, coord in enumerate(interior_centroid):

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -58,7 +58,7 @@ def get_cycle_interior(cyclic_group: np.ndarray) -> np.ndarray:
         ):
             interior[x, y] = False
 
-        for x_inc, y_inc in adjacencies:
+        for x_inc, y_inc in ADJACENCIES:
             x_new = x + x_inc
             y_new = y + y_inc
             if (

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -1,0 +1,186 @@
+import argparse
+import itertools
+import re
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from go_attack.go import Color, Game
+
+BOARD_LEN = 19
+
+adv_names = ["adv"]
+victim_names = ["victim", "b18-"]
+
+
+def get_sgf_property(property_name: str, sgf_string: str) -> str:
+    return re.search(f"{property_name}\[([^\]]+)\]", sgf_string).group(1)
+
+
+def get_cycle_interior(cyclic_group: np.ndarray) -> (np.ndarray, (int, int)):
+    """Returns boolean map of points inside cyclic group.
+
+    Args
+    ----
+    cyclic_group:
+      Boolean map of cyclic group points.
+    """
+
+    visited = np.zeros_like(cyclic_group, dtype=bool)
+    interior = ~cyclic_group
+    adjacencies = [[0, -1], [0, 1], [-1, 0], [1, 0]]
+    x_max, y_max = cyclic_group.shape
+
+    def dfs(x, y, definitely_not_interior=False):
+        visited[x, y] = True
+
+        if (
+            definitely_not_interior
+            or x == 0
+            or y == 0
+            or x == x_max - 1
+            or y == y_max - 1
+        ):
+            interior[x, y] = False
+            definitely_not_interior = True
+
+        for x_inc, y_inc in adjacencies:
+            x_new = x + x_inc
+            y_new = y + y_inc
+            if (
+                not (0 <= x_new < x_max)
+                or not (0 <= y_new < y_max)
+                or cyclic_group[x_new, y_new]
+            ):
+                continue
+            if not visited[x_new, y_new]:
+                dfs(x_new, y_new, definitely_not_interior=definitely_not_interior)
+            if not interior[x_new, y_new]:
+                interior[x, y] = False
+
+    for x, y in np.ndindex(cyclic_group.shape):
+        if not visited[x, y] and not cyclic_group[x, y]:
+            dfs(x, y)
+
+    return interior
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("files", type=Path, nargs="+")
+    parser.add_argument("--title", type=str, default="")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    cycle_heatmap = np.zeros((BOARD_LEN, BOARD_LEN))
+    adv_heatmap = np.zeros((BOARD_LEN, BOARD_LEN))
+    victim_heatmap = np.zeros((BOARD_LEN, BOARD_LEN))
+    interior_adv_heatmap = np.zeros((BOARD_LEN, BOARD_LEN))
+    interior_victim_heatmap = np.zeros((BOARD_LEN, BOARD_LEN))
+    num_cycles = 0
+    for path in args.files:
+        if ".sgf" in path.suffix:
+            sgf_files = [path]
+        else:
+            sgf_files = itertools.chain(path.glob("**/*.sgf"), path.glob("**/*.sgfs"))
+        for sgf_file in sgf_files:
+            for sgf_string in open(sgf_file):
+                if int(get_sgf_property("SZ", sgf_string)) != BOARD_LEN:
+                    continue
+
+                b_name = get_sgf_property("PB", sgf_string)
+                w_name = get_sgf_property("PW", sgf_string)
+                winner = get_sgf_property("RE", sgf_string)[0]
+                adv_is_w = False
+                adv_is_b = False
+                for name in adv_names:
+                    if name in b_name:
+                        adv_is_b = True
+                    if name in w_name:
+                        adv_is_w = True
+                for name in victim_names:
+                    if name in b_name:
+                        adv_is_w = True
+                    if name in w_name:
+                        adv_is_b = True
+                assert (
+                    adv_is_w != adv_is_b
+                ), f"Couldn't determine adversary: {b_name} vs. {w_name}"
+                adv_win = (adv_is_b and winner == "B") or (adv_is_w and winner == "W")
+                if not adv_win:
+                    continue
+                adv_color = Color.BLACK if adv_is_b else Color.WHITE
+
+                game = Game.from_sgf(sgf_string)
+
+                for i, (prev_board, board) in enumerate(
+                    zip(game.board_states, game.board_states[1:])
+                ):
+                    player_color = Color.BLACK if i % 2 == 0 else Color.WHITE
+                    if player_color != adv_color:
+                        continue
+                    opponent_color = player_color.opponent()
+                    opponent_stones = prev_board == opponent_color.value
+                    empty_points = board == Color.EMPTY.value
+                    captured_stones = empty_points & opponent_stones
+                    if np.count_nonzero(captured_stones) > 20:
+                        num_cycles += 1
+                        interior = get_cycle_interior(captured_stones)
+
+                        # Flip cyclic group so that it's in the top-left corner
+                        interior_centroid = np.average(interior.nonzero(), axis=1)
+                        for axis, coord in enumerate(interior_centroid):
+                            if coord > BOARD_LEN / 2:
+                                board = np.flip(board, axis)
+                                captured_stones = np.flip(captured_stones, axis)
+                                interior = np.flip(interior, axis)
+
+                        adv_stones = board == player_color.value
+                        victim_stones = board == opponent_color.value
+                        interior_adv_stones = interior & adv_stones
+                        interior_victim_stones = interior & victim_stones
+
+                        cycle_heatmap += captured_stones
+                        adv_heatmap += adv_stones
+                        victim_heatmap += victim_stones
+                        interior_adv_heatmap += interior_adv_stones
+                        interior_victim_heatmap += interior_victim_stones
+
+                        break
+
+    fig, axs = plt.subplots(3, 2)
+
+    def plot_data(x, y, data, title):
+        ax = axs[x, y]
+        im = ax.imshow(data / num_cycles, cmap="hot", interpolation="nearest", vmax=1.0)
+        ax.title.set_text(title)
+        return im
+
+    plot_data(0, 0, cycle_heatmap, "Cyclic group")
+    axs[0, 1].axis("off")
+    plot_data(1, 0, adv_heatmap, "Adversary stones")
+    plot_data(1, 1, interior_adv_heatmap, "Interior adversary stones")
+    plot_data(2, 0, victim_heatmap, "Victim stones")
+    im = plot_data(2, 1, interior_victim_heatmap, "Interior victim stones")
+    for _, ax in np.ndenumerate(axs):
+        ax.set_xticks(range(0, board.shape[0], 5))
+        ax.set_yticks(range(0, board.shape[1], 5))
+        ax.set_xticks(range(board.shape[0]), minor=True)
+        ax.set_yticks(range(board.shape[1]), minor=True)
+        ax.xaxis.set_ticks_position("both")
+        ax.yaxis.set_ticks_position("both")
+    fig.suptitle(f"{args.title}, sample size of {num_cycles}")
+    fig.tight_layout()
+    fig.colorbar(im, ax=axs.ravel().tolist(), location="left")
+
+    if args.output is None:
+        plt.show()
+    else:
+        fig.savefig(args.output)
+
+
+if __name__ == "__main__":
+    main()
+    # import cProfile
+    # cProfile.run('main()', sort='cumtime')

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -181,18 +181,23 @@ def get_cyclic_capture(
         if len(interior_points[0]) == 0:
             continue
 
-        # To get rid of some symmetries, flip cyclic group so that it's in
-        # the top-left corner. (There are still two symmetries that this
-        # doesn't distinguish since you can flip the board diagonally and
-        # keep the cyclic group in the top-left. This also doesn't get rid
-        # of symmetries if the cyclic group is near the center of either the
-        # x or y axis.)
+        # To get rid of some symmetries, flip cyclic group that its center is in
+        # the top-left corner, and flip across the diagonal if the center's row
+        # coordinate is larger than the column coordinate.
+        # (It's ambiguous which symmetry to use when the center lies upon an
+        # axis of reflection---we don't try to handle this.)
         interior_centroid = np.average(interior.nonzero(), axis=1)
         for axis, coord in enumerate(interior_centroid):
             if coord > BOARD_LEN / 2:
+                interior_centroid[axis] = BOARD_LEN - 1 - coord
                 board = np.flip(board, axis)
                 captured_stones = np.flip(captured_stones, axis)
                 interior = np.flip(interior, axis)
+        if interior_centroid[0] > interior_centroid[1]:
+            interior_centroid[[0, 1]] = interior_centroid[[1, 0]]
+            board = board.T
+            captured_stones = captured_stones.T
+            interior = interior.T
 
         adversary_stones = board == adversary_color.value
         victim_stones = board == victim_color.value

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -14,6 +14,8 @@ from tqdm import tqdm
 from go_attack.go import Color, Game
 
 BOARD_LEN = 19
+# When this many stones or more are captured in one move, we check if it's a
+# cyclic group.
 CAPTURE_GROUP_SIZE_THRESHOLD = 20
 
 # Substrings that appear uniquely in adversaries' and victims' names and are

--- a/scripts/plot_cycle_shapes.py
+++ b/scripts/plot_cycle_shapes.py
@@ -42,7 +42,6 @@ def get_cycle_interior(cyclic_group: np.ndarray) -> np.ndarray:
     adjacencies = [[0, -1], [0, 1], [-1, 0], [1, 0]]
     x_max, y_max = cyclic_group.shape
 
-
     # Any point that has a path that reaches the edge of the board without
     # intersecting with the cyclic group is not interior. We DFS to find these
     # non-interior points.
@@ -146,8 +145,8 @@ def main():
 
                 game = Game.from_sgf(sgf_string)
 
-                # For each move, check for a capture by diffing the previous board with the
-                # current board.
+                # For each move, check for a capture by diffing the previous
+                # board with the current board.
                 #
                 # The victim can suicide its cyclic group, so we need to check
                 # all moves, not just the adversary's moves, for a capture.


### PR DESCRIPTION
Adds script for generating heat map visualizations of adversaries' cyclic group shapes. 

Maybe belongs in KataGoVisualizer, except we need to use `go_attack.go.Game` to simulate each game and find the cyclic capture.

Experiment page: https://www.notion.so/chaiberkeley/heat-map-visualizations-of-cyclic-adversaries-e6604589c2364aa1803b2f1738f0547d?pvs=4