### PR TITLE
configs/compute: Increase game threads 128→256, fix multi-GPU usage

### DIFF
--- a/configs/compute/1gpu.cfg
+++ b/configs/compute/1gpu.cfg
@@ -1,11 +1,11 @@
-numGameThreads = 128
+numGameThreads = 256
 
 # GPU Settings-------------------------------------------------------------------------------
 # 1xA6000
 # 2 sockets of AMD EPYC 7763 64-Core Processors = 128 physical cores
 #                                                 each core has 2 threads
 
-nnMaxBatchSize = 128
+nnMaxBatchSize = 256
 nnCacheSizePowerOfTwo = 21
 nnMutexPoolSizePowerOfTwo = 17
 numNNServerThreadsPerModel = 1

--- a/configs/compute/2gpu.cfg
+++ b/configs/compute/2gpu.cfg
@@ -1,3 +1,5 @@
 @include 1gpu.cfg
 
-numGameThreads = 256
+numGameThreads = 512
+numNNServerThreadsPerModel = 2
+deviceToUseThread1 = 1

--- a/configs/compute/3gpu.cfg
+++ b/configs/compute/3gpu.cfg
@@ -1,3 +1,5 @@
 @include 2gpu.cfg
 
-numGameThreads = 384
+numGameThreads = 768
+numNNServerThreadsPerModel = 3
+deviceToUseThread2 = 2

--- a/configs/compute/4gpu.cfg
+++ b/configs/compute/4gpu.cfg
@@ -1,3 +1,5 @@
 @include 3gpu.cfg
 
-numGameThreads = 512
+numGameThreads = 1024
+numNNServerThreadsPerModel = 4
+deviceToUseThread3 = 3

--- a/configs/compute/5gpu.cfg
+++ b/configs/compute/5gpu.cfg
@@ -1,3 +1,5 @@
 @include 4gpu.cfg
 
-numGameThreads = 640
+numGameThreads = 1280
+numNNServerThreadsPerModel = 5
+deviceToUseThread4 = 4

--- a/configs/compute/6gpu.cfg
+++ b/configs/compute/6gpu.cfg
@@ -1,3 +1,5 @@
 @include 5gpu.cfg
 
-numGameThreads = 768
+numGameThreads = 1536
+numNNServerThreadsPerModel = 6
+deviceToUseThread5 = 5

--- a/configs/compute/7gpu.cfg
+++ b/configs/compute/7gpu.cfg
@@ -1,3 +1,5 @@
 @include 6gpu.cfg
 
-numGameThreads = 896
+numGameThreads = 1792
+numNNServerThreadsPerModel = 7
+deviceToUseThread6 = 6

--- a/configs/compute/8gpu.cfg
+++ b/configs/compute/8gpu.cfg
@@ -1,3 +1,5 @@
 @include 7gpu.cfg
 
-numGameThreads = 1024
+numGameThreads = 2048
+numNNServerThreadsPerModel = 8
+deviceToUseThread7 = 7


### PR DESCRIPTION
* Increase game threads 128->256: I had found [several months back](https://www.notion.so/chaiberkeley/debugging-victimplay-throughput-being-lower-than-expected-bc376db69a5a4343bd6c609dcec1ca4b?pvs=4#82543a2589c348d3ae3940584fd72abf) that 256 game threads had a little more throughput than 128 threads
* Increase server threads to match the number of GPUs, otherwise we're not actually making use of multiple GPUs
  * We previously were doing this but I had accidentally removed it in a [previous PR](https://github.com/AlignmentResearch/go_attack/pull/121)