### PR TITLE
Add config param to force GTP to not allow rule changes

### DIFF
--- a/configs/gtp-amcts.cfg
+++ b/configs/gtp-amcts.cfg
@@ -28,3 +28,7 @@ conservativePass = false
 # subtreeValueBiasWeightExponent = 0.8
 # fpuParentWeightByVisitedPolicy = false
 # enablePassingHacks = false
+
+# Our bots only trained with Tromp-Taylor rules. This setting makes GTP ignore
+# commands that change the rules.
+ignoreGTPRuleChanges = true

--- a/configs/gtp-base.cfg
+++ b/configs/gtp-base.cfg
@@ -5,11 +5,13 @@ logAllGTPCommunication = false
 # Remove unnecessary non-determinism
 numSearchThreads = 1
 
-# For compatibility with other engines, we need to set multiStoneSuicideLegal, which
-# means we also need to set the other rules instead of relying on rules = tromp-taylor
+# Since Leela and ELF do not allow multi-stone suicide, when playing against
+# them we need to set multiStoneSuicideLegal to false. Then we also need to set
+# the other rules instead of relying on rules = tromp-taylor.
+# multiStoneSuicideLegal = false
+multiStoneSuicideLegal = true
 koRule = POSITIONAL
 scoringRule = AREA
-multiStoneSuicideLegal = false
 
 allowResignation = false
 resignConsecTurns = 3


### PR DESCRIPTION
Our bots are only trained with Tromp-Taylor rules, but KGS doesn't have Tromp-Taylor rules. If a bot plays with non-Tromp-Taylor rules, then because the rules are features of the NN input, all NN inputs will be out-of-distribution. We therefore want to force our bots to always think they're playing with Tromp-Taylor rules (at the very least for NN evaluation)

This PR:
* Incorporates https://github.com/AlignmentResearch/KataGo-custom/pull/109: adds a config param ignoreGTPRuleChanges (in the same vein as the existing KataGo-raw config param ignoreGTPAndForceKomi) that makes KataGo ignore rule changes from `katago-set-rule`, `katago-set-rules`, `kgs-rules`, and `loadsgf`.
* Unrelatedly: default `multiStoneSuicideLegal = true` in our GTP config (previously we had made this false for Leela/ELF transfer experiments, but these days all our GTP evals are not against Leela/ELF and I don't want to make the mistake of forgetting to set this param to `true`)