### PR TITLE
sabaki: Update models

### DIFF
--- a/sabaki/README.md
+++ b/sabaki/README.md
@@ -36,7 +36,7 @@ The base KataGo models are downloaded from https://katagotraining.org/networks/.
   and the fourth line is the initial commands passed to gtp
   (in this case giving the bot infinite time to make moves).
   See below for more sample configs.
-4. After adding a config, you can follow the instructions at https://youtu.be/6ZA_saVHyTA to play against newly configured engine.
+4. After adding a config, you can follow the instructions at https://youtu.be/6ZA_saVHyTA to play against the newly configured engine.
 
 In particular, the following config runs our cyclic-adversary, assuming this
 repo is checked out at `/Users/ttw/code/go_attack/engines/` (the paths will need

--- a/sabaki/README.md
+++ b/sabaki/README.md
@@ -52,12 +52,6 @@ time_settings 0 1 0
 ## More sample bot configs
 You'll need to change the paths to the models and executables for your machine.
 ```
-# Weaker cyclic-adversary (with dragonslayer strategy)
-cyclic-adv-s349m-v600-vm-cp505-v1-s
-/Users/ttw/code/go_attack/engines/KataGo-custom/cpp/katago
-gtp -model /Users/ttw/code/go_attack/sabaki/models/adv/cyclic-adv-s349284096-d87808728.bin.gz -victim-model /Users/ttw/code/go_attack/sabaki/models/victims/kata1-b40c256-s11840935168-d2898845681.bin.gz -config /Users/ttw/code/go_attack/configs/sabaki/gtp-adv600-vm1-s.cfg
-time_settings 0 1 0
-
 # Pass-adversary
 pass-adv-s34m-v600-vs-cp505-v1-s
 /Users/ttw/code/go_attack/engines/KataGo-custom/cpp/katago

--- a/sabaki/README.md
+++ b/sabaki/README.md
@@ -8,9 +8,8 @@ If you are on MacOS, you can install using Homebrew with the command
 
 ## Download adversary and victim neural nets
 Run `sabaki/scripts/download-models.sh`
-to automatically download the strongest adversaries and KataGo models.
-
-We host the models on Google Drive here: https://drive.google.com/drive/folders/1-bGX-NQOh6MuRPoXJgYHb9-jWRJvviSg?usp=sharing
+to automatically download the original cyclic adversary and pass adversary.
+Find other models on our [Google Drive](https://drive.google.com/drive/folders/1-bGX-NQOh6MuRPoXJgYHb9-jWRJvviSg?usp=sharing).
 
 The base KataGo models are downloaded from https://katagotraining.org/networks/.
 
@@ -45,7 +44,7 @@ to be adjusted depending on where your copy of the repo is located):
 ```
 cyclic-adv-s545m-v600-vm-cp505-v1-s
 /Users/ttw/code/go_attack/engines/KataGo-custom/cpp/katago
-gtp -model /Users/ttw/code/go_attack/sabaki/models/adv/cyclic-adv-s545065216-d136760487.bin.gz -victim-model /Users/ttw/code/go_attack/sabaki/models/victims/kata1-b40c256-s11840935168-d2898845681.bin.gz -config /Users/ttw/code/go_attack/configs/sabaki/gtp-adv600-vm1-s.cfg
+gtp -model /Users/ttw/code/go_attack/sabaki/models/adv/cyclic/model.bin.gz -victim-model /Users/ttw/code/go_attack/sabaki/models/victims/kata1-b40c256-s11840935168-d2898845681.bin.gz -config /Users/ttw/code/go_attack/configs/sabaki/gtp-adv600-vm1-s.cfg
 time_settings 0 1 0
 ```
 
@@ -55,7 +54,7 @@ You'll need to change the paths to the models and executables for your machine.
 # Pass-adversary
 pass-adv-s34m-v600-vs-cp505-v1-s
 /Users/ttw/code/go_attack/engines/KataGo-custom/cpp/katago
-gtp -model /Users/ttw/code/go_attack/sabaki/models/adv/pass-adv-s34090496-d8262123.bin.gz -victim-model /Users/ttw/code/go_attack/sabaki/models/victims/kata1-b40c256-s11840935168-d2898845681.bin.gz -config /Users/ttw/code/go_attack/configs/sabaki/gtp-adv600-vm1-s.cfg 
+gtp -model /Users/ttw/code/go_attack/sabaki/models/adv/pass/model.bin.gz -victim-model /Users/ttw/code/go_attack/sabaki/models/victims/kata1-b40c256-s11840935168-d2898845681.bin.gz -config /Users/ttw/code/go_attack/configs/sabaki/gtp-adv600-vm1-s.cfg 
 time_settings 0 1 0
 
 # Latest with 128 visits
@@ -81,7 +80,7 @@ and make sure Docker works on M.
 # Cyclic-adversary over ssh
 ssh-cyclic-adv-s545m-v600-vm-cp505-v1-s
 ssh
-rnn -tt 'bash -l -c "/nas/ucb/tony/go-attack/gtp-host/go_attack/sabaki/scripts/docker-katago.sh custom gtp -model /models/adv/cyclic-adv-s545065216-d136760487.bin.gz -victim-model /models/victims/kata1-b40c256-s11840935168-d2898845681.bin.gz -config /go_attack/configs/sabaki/gtp-adv600-vm1-s.cfg -config /go_attack/configs/compute/1gpu.cfg"'
+rnn -tt 'bash -l -c "/nas/ucb/tony/go-attack/gtp-host/go_attack/sabaki/scripts/docker-katago.sh custom gtp -model /models/adv/cyclic/model.bin.gz -victim-model /models/victims/kata1-b40c256-s11840935168-d2898845681.bin.gz -config /go_attack/configs/sabaki/gtp-adv600-vm1-s.cfg -config /go_attack/configs/compute/1gpu.cfg"'
 time_settings 0 1 0
 ```
 

--- a/sabaki/scripts/download-models.sh
+++ b/sabaki/scripts/download-models.sh
@@ -7,14 +7,6 @@ mkdir -p $GIT_ROOT/sabaki/models/victims
 
 # Download models
 
-# cyclic-adv-s349284096-d87808728.bin.gz
-wget --content-disposition 'https://drive.google.com/uc?export=download&id=1Qktfjfr6YwplF50T-LMXkFK_qG1UXeiy' \
-     -P $GIT_ROOT/sabaki/models/adv/ -q --show-progress
-
-# cyclic-adv-s497721856-d125043118.bin.gz
-wget --content-disposition 'https://drive.google.com/uc?export=download&id=1TDSwJ_i0CHF_Ksf7lOaQIorpMu976fja' \
-     -P $GIT_ROOT/sabaki/models/adv/ -q --show-progress
-
 # cyclic-adv-s545065216-d136760487.bin.gz
 wget --content-disposition 'https://drive.google.com/uc?export=download&id=1gwD0nQsuE7aD92YJ66l82qtXR97A_lt1' \
      -P $GIT_ROOT/sabaki/models/adv/ -q --show-progress

--- a/sabaki/scripts/download-models.sh
+++ b/sabaki/scripts/download-models.sh
@@ -5,7 +5,7 @@ rm -rf $GIT_ROOT/sabaki/models
 mkdir -p $GIT_ROOT/sabaki/models/adv
 mkdir -p $GIT_ROOT/sabaki/models/victims
 
-# Download models
+# Download a few models
 
 # Original cyclic adversary
 mkdir -p $GIT_ROOT/sabaki/models/adv/cyclic

--- a/sabaki/scripts/download-models.sh
+++ b/sabaki/scripts/download-models.sh
@@ -7,13 +7,15 @@ mkdir -p $GIT_ROOT/sabaki/models/victims
 
 # Download models
 
-# cyclic-adv-s545065216-d136760487.bin.gz
-wget --content-disposition 'https://drive.google.com/uc?export=download&id=1gwD0nQsuE7aD92YJ66l82qtXR97A_lt1' \
-     -P $GIT_ROOT/sabaki/models/adv/ -q --show-progress
+# Original cyclic adversary
+mkdir -p $GIT_ROOT/sabaki/models/adv/cyclic
+wget --content-disposition 'https://drive.google.com/uc?export=download&id=1O2zD1HpxpaPKeRLPuSSUMmznkgM0HeXO' \
+     -P $GIT_ROOT/sabaki/models/adv/cyclic -q --show-progress
 
 # pass-adv-s34090496-d8262123.bin.gz
-wget --content-disposition 'https://drive.google.com/uc?export=download&id=1YMcLtSfqn8Qq05iyrisNBim8WtiPPKbx' \
-     -P $GIT_ROOT/sabaki/models/adv/ -q --show-progress
+mkdir -p $GIT_ROOT/sabaki/models/adv/pass
+wget --content-disposition 'https://drive.google.com/uc?export=download&id=17xW8sFjmh7W3VOfR3_vNv9dk4ndJ9wBC' \
+     -P $GIT_ROOT/sabaki/models/adv/pass -q --show-progress
 
 wget --content-disposition 'https://media.katagotraining.org/uploaded/networks/models/kata1/kata1-b40c256-s11840935168-d2898845681.bin.gz' \
      -P $GIT_ROOT/sabaki/models/victims/ -q --show-progress


### PR DESCRIPTION
I updated our [Google drive of models](https://drive.google.com/drive/u/3/folders/1-bGX-NQOh6MuRPoXJgYHb9-jWRJvviSg):
* Delete older cyclic models (s349m, s498m)
* Upload models used in our defense paper: ViT, ViT adversary, v9, a9, atari adversary, continuous adversary, gift adversary, cyclic-s227m, attack-may23
* Upload Python training weights for every model
* Upload training data for all of our paper models, except for pass adversary (pass adversary data got deleted when /nas/ucb/tony was deleted)

This PR updates the download script in `sabaki/` to not use the older cyclic models and to point to the new download URLs for the cyclic + pass adversary.