### PR TITLE
configs: Make active-experiment.cfg match latest experiments

### DIFF
--- a/configs/active-experiment.cfg
+++ b/configs/active-experiment.cfg
@@ -4,14 +4,36 @@
 maxVisits0 = 32 # increase this to make victim stronger, though if the curriculum script is running then it'll override this
 # Uncomment this for pass-hardening
 # passingBehavior0 = avoid-pass-alive-territory
-# Normally optimism is 0 during training, but we'll set the victim's optimism
-# to the levels seen in eval.
-policyOptimism0=1.0
-rootPolicyOptimism0=0.2
 
-# LCB is turned off for selfplay since lightvector found that LCB make training
+# LCB is turned off for selfplay since lightvector found that LCB makes training
 # progress slightly worse, though LCB makes eval much stronger:
 # https://lifein19x19.com/viewtopic.php?p=278323#p278323
-# For victimplay it's a bit disconcerting to see a large train/eval gap, so we
-# may want to re-enable LCB, or at least enable LCB for the victim.
-# useLcbForSelfplayMove = true
+# For victimplay it's a bit disconcerting to see a large win rate gap between
+# training and evaluation, so we re-enable LCB.
+useLcbForSelfplayMove = true
+
+# Since the victim isn't being trained, we set its parameters from training-like
+# values to evaluation-like values.
+antiMirror0 = true
+chosenMoveTemperature0 = 0.10
+chosenMoveTemperatureEarly0 = 0.50
+conservativePass0 = true
+cpuctExploration0 = 1.0
+cpuctExplorationLog0 = 0.45
+cpuctUtilityStdevScale0 = 0.85
+dynamicScoreCenterZeroWeight0 = 0.2
+enablePassingHacks0 = true
+fillDameBeforePass0 = true
+policyOptimism0 = 1.0
+rootDesiredPerChildVisitsCoeff0 = 0
+rootFpuReductionMax0 = 0.1
+rootNoiseEnabled0 = false
+rootNumSymmetriesToSample0 = 1
+rootPolicyOptimism0 = 0.2
+rootPolicyTemperature0 = 1.0
+rootPolicyTemperatureEarly0 = 1.0
+subtreeValueBiasFactor0 = 0.45
+subtreeValueBiasWeightExponent0 = 0.85
+useNoisePruning0 = true
+useUncertainty0 = true
+valueWeightExponent0 = 0.25

--- a/configs/amcts/victimplay.cfg
+++ b/configs/amcts/victimplay.cfg
@@ -111,7 +111,7 @@ cpuctExplorationLog = 0.28
 fpuReductionMax = 0.2
 rootFpuReductionMax = 0.0
 valueWeightExponent = 0.5
-subtreeValueBiasFactor = 0.35
+subtreeValueBiasFactor = 0.30
 subtreeValueBiasWeightExponent = 0.8
 
 mutexPoolSize = 64

--- a/configs/amcts/victimplay.cfg
+++ b/configs/amcts/victimplay.cfg
@@ -88,25 +88,26 @@ rootNumSymmetriesToSample = 4
 useLcbForSelection = true
 lcbStdevs = 5.0
 minVisitPropForLCB = 0.15
+useNonBuggyLcb = true
 
 # Internal params---------------------------------------------------------------------------------
 
 winLossUtilityFactor = 1.0
-staticScoreUtilityFactor = 0.00
-dynamicScoreUtilityFactor = 0.40
+staticScoreUtilityFactor = 0.05
+dynamicScoreUtilityFactor = 0.30
 dynamicScoreCenterZeroWeight = 0.25
-dynamicScoreCenterScale = 0.50
+dynamicScoreCenterScale = 0.75
 noResultUtilityForWhite = 0.0
 drawEquivalentWinsForWhite = 0.5
 
 rootEndingBonusPoints = 0.5
 rootPruneUselessMoves = true
 
-rootPolicyTemperatureEarly = 1.25
+rootPolicyTemperatureEarly = 1.5
 rootPolicyTemperature = 1.1
 
-cpuctExploration = 1.1
-cpuctExplorationLog = 0.0
+cpuctExploration = 1.05
+cpuctExplorationLog = 0.28
 fpuReductionMax = 0.2
 rootFpuReductionMax = 0.0
 valueWeightExponent = 0.5


### PR DESCRIPTION
Update active-experiment.cfg to match the config params used in many of our recent training runs:
* Make victim params closer to eval
* Make adversary params closer to most up-to-date KataGo-raw training config https://github.com/lightvector/KataGo/blob/master/cpp/configs/training/selfplay8mainb18.cfg

E.g., (1) `atari-adversary` and (2) `a9` were trained with these params, which suggests that with these params we can still (1) discover a cyclic attack (at least if warmstarted from cyclic-s227m) and (2) train a potent cyclic attack