### PR TITLE
gitmodules: Switch from SSH to HTTPS to make Kaniko build work more easily

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "controllers/gogui"]
 	path = controllers/gogui
-	url = git@github.com:AlignmentResearch/gogui.git
+	url = https://github.com/AlignmentResearch/gogui.git
 [submodule "engines/KataGo-custom"]
 	path = engines/KataGo-custom
-	url = git@github.com:AlignmentResearch/KataGo-custom.git
+	url = https://github.com/AlignmentResearch/KataGo-custom.git
 [submodule "engines/KataGo-raw"]
 	path = engines/KataGo-raw
-	url = git@github.com:lightvector/KataGo.git
+	url = https://github.com/lightvector/KataGo.git
 [submodule "engines/KataGo-tensorflow"]
 	path = engines/KataGo-tensorflow
-	url = git@github.com:AlignmentResearch/KataGo-custom.git
+	url = https://github.com/AlignmentResearch/KataGo-custom.git


### PR DESCRIPTION
Kaniko, which we use to build images on Flamingo, does not work with SSH submodules, because it will hit an auth error from not having the appropriate SSH key. We could create a Kubernetes secret containing an SSH private key and mount it into the Kaniko build container, but I think this is a security vulnerability since GitHub SSH has no fine-grained permission control, it just gives full read/write access to all your repos (e.g., say someone infiltrates the official Kaniko repo and adds malicious code that steals your SSH private key).

This PR changes go_attack submodules to use HTTPS instead of SSH. This allows Kaniko to build the go_attack Docker image. I've also added a few sentences in the [Flamingo wiki](https://github.com/AlignmentResearch/flamingo/wiki/Build-Docker-images-on-the-cluster:-Kaniko#authentication-3-git-submodules) more clearly highlighting that submodules should be specified with HTTPS vs SSH.

I think SSH is supposed to be more secure than HTTPS in general. If users prefer SSH, it looks like users can configure on their own if they'd like to [force SSH to be used instead of HTTPS (this link actually does the opposite, forcing HTTPS to be used)](https://stackoverflow.com/a/66537201/4865149). Or they could temporarily change `.gitmodules`, call `git submodule sync`, and revert it back.

(This has only come up now because I previously always built on the CHAI machines, but I've finally lost access to them now. The images are a few dozen GB collectively so I don't have enough space on my local machine to build them without buying an external drive.)