### PR TITLE
active-experiment: More victim config fixes

### DIFF
--- a/configs/active-experiment.cfg
+++ b/configs/active-experiment.cfg
@@ -32,6 +32,10 @@ rootNumSymmetriesToSample0 = 1
 rootPolicyOptimism0 = 0.2
 rootPolicyTemperature0 = 1.0
 rootPolicyTemperatureEarly0 = 1.0
+# Setting the rootSymmetryPruning0 param triggers the assert
+# `!toMoveBot->searchParams.rootSymmetryPruning' in `extractPolicyTarget()`.
+# rootSymmetryPruning0 = true
+staticScoreUtilityFactor0 = 0.1
 subtreeValueBiasFactor0 = 0.45
 subtreeValueBiasWeightExponent0 = 0.85
 useNoisePruning0 = true

--- a/configs/active-experiment.cfg
+++ b/configs/active-experiment.cfg
@@ -32,9 +32,9 @@ rootNumSymmetriesToSample0 = 1
 rootPolicyOptimism0 = 0.2
 rootPolicyTemperature0 = 1.0
 rootPolicyTemperatureEarly0 = 1.0
-# Setting the rootSymmetryPruning0 param triggers the assert
-# `!toMoveBot->searchParams.rootSymmetryPruning' in `extractPolicyTarget()`.
-# rootSymmetryPruning0 = true
+# Evaluation has `rootSymmetryPruning0 = true`, but we don't set it here as it
+# triggers the assert `!toMoveBot->searchParams.rootSymmetryPruning' in
+# `extractPolicyTarget()`.
 staticScoreUtilityFactor0 = 0.1
 subtreeValueBiasFactor0 = 0.45
 subtreeValueBiasWeightExponent0 = 0.85

--- a/configs/match.cfg
+++ b/configs/match.cfg
@@ -37,8 +37,4 @@ rootSymmetryPruning = true
 antiMirror = true
 fillDameBeforePass = true
 enablePassingHacks = true
-# TODO(tomtseng): conservativePass  has a bug that sometimes makes the bot weaker
-# to passing-based attacks. We should merge commits up to
-# https://github.com/lightvector/KataGo/commit/eea5d0cbc3909ef55b81b364b19593d83f7aefa8
-# (Jan 11, 2023) into KataGo-custom before setting conservativePass to true.
-# conservativePass = true
+conservativePass = true


### PR DESCRIPTION
A few config changes I failed to include in #144:
* In training, victim should have score utility 0.1 rather than 0.05 (documented in paper in appendix but failed to add in #144)
* In eval, conservativePass should be on to match GTP default
* Add comment about why rootSymmetryPruning is not the same between training and eval